### PR TITLE
Implement front-end routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 -   Add compatibility with PrimeVue 4 [#9](https://github.com/archesproject/arches-references/issues/9)
--   Add front-end routing [#19](https://github.com/archesproject/arches-references/pull/19)
+-   Add front-end routing [#4](https://github.com/archesproject/arches-references/issues/4)
 
 ### Changed
--   Generate URIs when not supplied [#17](https://github.com/archesproject/arches-references/pull/17)
+-   Generate URIs when not supplied [#8](https://github.com/archesproject/arches-references/issues/8)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
--  Added compatibility with PrimeVue 4 [#16](https://github.com/archesproject/arches-references/pull/16)
+-   Add compatibility with PrimeVue 4 [#9](https://github.com/archesproject/arches-references/issues/9)
+-   Add front-end routing [#19](https://github.com/archesproject/arches-references/pull/19)
 
 ### Changed
--  Generate URIs when not supplied [#17](https://github.com/archesproject/arches-references/pull/17)
+-   Generate URIs when not supplied [#17](https://github.com/archesproject/arches-references/pull/17)
 
 ### Fixed
 

--- a/arches_references/media/js/views/components/plugins/controlled-list-manager.js
+++ b/arches_references/media/js/views/components/plugins/controlled-list-manager.js
@@ -1,17 +1,11 @@
 import ko from 'knockout';
 
+import { routes } from '@/arches_references/routes.ts';
 import ControlledListManager from '@/arches_references/plugins/ControlledListManager.vue';
-import ControlledListsMain from '@/arches_references/components/ControlledListsMain.vue';
 import createVueApplication from 'utils/create-vue-application';
 import ControlledListManagerTemplate from 'templates/views/components/plugins/controlled-list-manager.htm';
 
 import { createRouter, createWebHistory } from 'vue-router';
-
-const routes = [
-  { path: '/plugins/controlled-list-manager', name: 'splash', component: ControlledListsMain },
-  { path: '/plugins/controlled-list-manager/list/:id', name: 'list', component: ControlledListsMain },
-  { path: '/plugins/controlled-list-manager/item/:id', name: 'item', component: ControlledListsMain },
-];
 
 const router = createRouter({
   history: createWebHistory(),

--- a/arches_references/media/js/views/components/plugins/controlled-list-manager.js
+++ b/arches_references/media/js/views/components/plugins/controlled-list-manager.js
@@ -1,12 +1,27 @@
 import ko from 'knockout';
 
 import ControlledListManager from '@/arches_references/plugins/ControlledListManager.vue';
+import ControlledListsMain from '@/arches_references/components/ControlledListsMain.vue';
 import createVueApplication from 'utils/create-vue-application';
 import ControlledListManagerTemplate from 'templates/views/components/plugins/controlled-list-manager.htm';
+
+import { createRouter, createWebHistory } from 'vue-router';
+
+const routes = [
+  { path: '/plugins/controlled-list-manager', name: 'splash', component: ControlledListsMain },
+  { path: '/plugins/controlled-list-manager/list/:id', name: 'list', component: ControlledListsMain },
+  { path: '/plugins/controlled-list-manager/item/:id', name: 'item', component: ControlledListsMain },
+];
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+});
 
 ko.components.register('controlled-list-manager', {
     viewModel: function() {
         createVueApplication(ControlledListManager).then((vueApp) => {
+            vueApp.use(router);
             vueApp.mount('#controlled-list-manager-mounting-point');
         });
     },

--- a/arches_references/src/arches_references/components/ControlledListsMain.vue
+++ b/arches_references/src/arches_references/components/ControlledListsMain.vue
@@ -38,6 +38,7 @@ const setDisplayedRow = (val: Selectable | null) => {
         router.push({ name: routes.item, params: { id: val.id } });
     }
 };
+// @ts-expect-error vue-tsc doesn't like arbitrary properties here
 provide(displayedRowKey, { displayedRow, setDisplayedRow });
 
 const selectedLanguage: Ref<Language> = ref(

--- a/arches_references/src/arches_references/components/ControlledListsMain.vue
+++ b/arches_references/src/arches_references/components/ControlledListsMain.vue
@@ -8,9 +8,9 @@ import Toast from "primevue/toast";
 
 import {
     displayedRowKey,
-    routes,
     selectedLanguageKey,
 } from "@/arches_references/constants.ts";
+import { routeNames } from "@/arches_references/routes.ts";
 import { dataIsList } from "@/arches_references/utils.ts";
 
 import ListHeader from "@/arches_references/components/misc/ListHeader.vue";
@@ -26,16 +26,16 @@ const displayedRow: Ref<Selectable | null> = ref(null);
 const setDisplayedRow = (val: Selectable | null) => {
     displayedRow.value = val;
     if (val === null) {
-        router.push({ name: routes.splash });
+        router.push({ name: routeNames.splash });
         return;
     }
     if (typeof val.id === "number") {
         return;
     }
     if (dataIsList(val)) {
-        router.push({ name: routes.list, params: { id: val.id } });
+        router.push({ name: routeNames.list, params: { id: val.id } });
     } else {
-        router.push({ name: routes.item, params: { id: val.id } });
+        router.push({ name: routeNames.item, params: { id: val.id } });
     }
 };
 // @ts-expect-error vue-tsc doesn't like arbitrary properties here

--- a/arches_references/src/arches_references/components/ControlledListsMain.vue
+++ b/arches_references/src/arches_references/components/ControlledListsMain.vue
@@ -89,4 +89,18 @@ provide(selectedLanguageKey, selectedLanguage);
     flex-direction: column;
     height: 100%;
 }
+
+:deep(h1, h5, h6) {
+    font-weight: 600;
+}
+
+:deep(h2, h3) {
+    font-weight: 600;
+    font-size: 1.6rem;
+}
+
+:deep(h4) {
+    font-weight: 600;
+    font-size: 1.33rem;
+}
 </style>

--- a/arches_references/src/arches_references/components/ControlledListsMain.vue
+++ b/arches_references/src/arches_references/components/ControlledListsMain.vue
@@ -1,12 +1,9 @@
 <script setup lang="ts">
 import arches from "arches";
-import { computed, provide, ref } from "vue";
+import { provide, ref } from "vue";
 import { useRouter } from "vue-router";
 
 import ConfirmDialog from "primevue/confirmdialog";
-import ProgressSpinner from "primevue/progressspinner";
-import Splitter from "primevue/splitter";
-import SplitterPanel from "primevue/splitterpanel";
 import Toast from "primevue/toast";
 
 import {
@@ -15,11 +12,9 @@ import {
     selectedLanguageKey,
 } from "@/arches_references/constants.ts";
 import { dataIsList } from "@/arches_references/utils.ts";
-import ControlledListSplash from "@/arches_references/components/misc/ControlledListSplash.vue";
-import ItemEditor from "@/arches_references/components/editor/ItemEditor.vue";
-import ListCharacteristics from "@/arches_references/components/editor/ListCharacteristics.vue";
+
 import ListHeader from "@/arches_references/components/misc/ListHeader.vue";
-import ListTree from "@/arches_references/components/tree/ListTree.vue";
+import MainSplitter from "@/arches_references/components/MainSplitter.vue";
 
 import type { Ref } from "vue";
 import type { Language } from "@/arches/types";
@@ -43,7 +38,6 @@ const setDisplayedRow = (val: Selectable | null) => {
         router.push({ name: routes.item, params: { id: val.id } });
     }
 };
-// @ts-expect-error vue-tsc doesn't like arbitrary properties here
 provide(displayedRowKey, { displayedRow, setDisplayedRow });
 
 const selectedLanguage: Ref<Language> = ref(
@@ -52,16 +46,6 @@ const selectedLanguage: Ref<Language> = ref(
     ) as Language,
 );
 provide(selectedLanguageKey, selectedLanguage);
-
-const panel = computed(() => {
-    if (!displayedRow.value) {
-        return ControlledListSplash;
-    }
-    if (dataIsList(displayedRow.value)) {
-        return ListCharacteristics;
-    }
-    return ItemEditor;
-});
 </script>
 
 <template>
@@ -69,34 +53,7 @@ const panel = computed(() => {
     <div style="width: calc(100vw - 50px); height: calc(100vh - 50px)">
         <div class="list-editor-container">
             <ListHeader />
-            <Splitter style="height: 100%">
-                <SplitterPanel
-                    :size="34"
-                    :min-size="25"
-                    style="display: flex; flex-direction: column"
-                >
-                    <Suspense>
-                        <ListTree />
-                        <template #fallback>
-                            <ProgressSpinner />
-                        </template>
-                    </Suspense>
-                </SplitterPanel>
-                <SplitterPanel
-                    :size="66"
-                    :min-size="25"
-                    :style="{
-                        margin: '1rem 0rem 4rem 1rem',
-                        overflowY: 'auto',
-                        paddingRight: '4rem',
-                    }"
-                >
-                    <component
-                        :is="panel"
-                        :key="displayedRow?.id ?? routes.splash"
-                    />
-                </SplitterPanel>
-            </Splitter>
+            <MainSplitter />
         </div>
     </div>
     <Toast />

--- a/arches_references/src/arches_references/components/ControlledListsMain.vue
+++ b/arches_references/src/arches_references/components/ControlledListsMain.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
 import arches from "arches";
 import { computed, provide, ref } from "vue";
+import { useRouter } from "vue-router";
 
+import ConfirmDialog from "primevue/confirmdialog";
 import ProgressSpinner from "primevue/progressspinner";
 import Splitter from "primevue/splitter";
 import SplitterPanel from "primevue/splitterpanel";
+import Toast from "primevue/toast";
 
 import {
     displayedRowKey,
+    routes,
     selectedLanguageKey,
 } from "@/arches_references/constants.ts";
 import { dataIsList } from "@/arches_references/utils.ts";
@@ -21,11 +25,23 @@ import type { Ref } from "vue";
 import type { Language } from "@/arches/types";
 import type { Selectable } from "@/arches_references/types";
 
-const splash = "splash";
+const router = useRouter();
 
 const displayedRow: Ref<Selectable | null> = ref(null);
 const setDisplayedRow = (val: Selectable | null) => {
     displayedRow.value = val;
+    if (val === null) {
+        router.push({ name: routes.splash });
+        return;
+    }
+    if (typeof val.id === "number") {
+        return;
+    }
+    if (dataIsList(val)) {
+        router.push({ name: routes.list, params: { id: val.id } });
+    } else {
+        router.push({ name: routes.item, params: { id: val.id } });
+    }
 };
 // @ts-expect-error vue-tsc doesn't like arbitrary properties here
 provide(displayedRowKey, { displayedRow, setDisplayedRow });
@@ -49,37 +65,64 @@ const panel = computed(() => {
 </script>
 
 <template>
-    <div class="list-editor-container">
-        <ListHeader />
-        <Splitter style="height: 100%">
-            <SplitterPanel
-                :size="34"
-                :min-size="25"
-                style="display: flex; flex-direction: column"
-            >
-                <Suspense>
-                    <ListTree />
-                    <template #fallback>
-                        <ProgressSpinner />
-                    </template>
-                </Suspense>
-            </SplitterPanel>
-            <SplitterPanel
-                :size="66"
-                :min-size="25"
-                :style="{
-                    margin: '1rem 0rem 4rem 1rem',
-                    overflowY: 'auto',
-                    paddingRight: '4rem',
-                }"
-            >
-                <component
-                    :is="panel"
-                    :key="displayedRow?.id ?? splash"
-                />
-            </SplitterPanel>
-        </Splitter>
+    <!-- Subtract size of arches toolbars -->
+    <div style="width: calc(100vw - 50px); height: calc(100vh - 50px)">
+        <div class="list-editor-container">
+            <ListHeader />
+            <Splitter style="height: 100%">
+                <SplitterPanel
+                    :size="34"
+                    :min-size="25"
+                    style="display: flex; flex-direction: column"
+                >
+                    <Suspense>
+                        <ListTree />
+                        <template #fallback>
+                            <ProgressSpinner />
+                        </template>
+                    </Suspense>
+                </SplitterPanel>
+                <SplitterPanel
+                    :size="66"
+                    :min-size="25"
+                    :style="{
+                        margin: '1rem 0rem 4rem 1rem',
+                        overflowY: 'auto',
+                        paddingRight: '4rem',
+                    }"
+                >
+                    <component
+                        :is="panel"
+                        :key="displayedRow?.id ?? routes.splash"
+                    />
+                </SplitterPanel>
+            </Splitter>
+        </div>
     </div>
+    <Toast />
+    <ConfirmDialog
+        :draggable="false"
+        :pt="{
+            root: {
+                style: {
+                    fontSize: 'small',
+                },
+            },
+            header: {
+                style: {
+                    background: 'var(--p-navigation)',
+                    color: 'white',
+                    borderRadius: '1rem',
+                    marginBottom: '1rem',
+                },
+            },
+            title: {
+                style: {
+                    fontWeight: 800,
+                },
+            },
+        }"
+    />
 </template>
 
 <style scoped>

--- a/arches_references/src/arches_references/components/MainSplitter.vue
+++ b/arches_references/src/arches_references/components/MainSplitter.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { computed, inject } from "vue";
+
+import ProgressSpinner from "primevue/progressspinner";
+import Splitter from "primevue/splitter";
+import SplitterPanel from "primevue/splitterpanel";
+
+import { displayedRowKey, routes } from "@/arches_references/constants.ts";
+import { dataIsList } from "@/arches_references/utils.ts";
+import ControlledListSplash from "@/arches_references/components/misc/ControlledListSplash.vue";
+import ItemEditor from "@/arches_references/components/editor/ItemEditor.vue";
+import ListCharacteristics from "@/arches_references/components/editor/ListCharacteristics.vue";
+import ListTree from "@/arches_references/components/tree/ListTree.vue";
+
+import type { Ref } from "vue";
+import type { ControlledList } from "@/arches_references/types";
+
+const { displayedRow } = inject(displayedRowKey) as unknown as {
+    displayedRow: Ref<ControlledList>;
+};
+
+const panel = computed(() => {
+    if (!displayedRow.value) {
+        return ControlledListSplash;
+    }
+    if (dataIsList(displayedRow.value)) {
+        return ListCharacteristics;
+    }
+    return ItemEditor;
+});
+</script>
+
+<template>
+    <Splitter style="height: 100%">
+        <SplitterPanel
+            :size="34"
+            :min-size="25"
+            style="display: flex; flex-direction: column"
+        >
+            <Suspense>
+                <ListTree />
+                <template #fallback>
+                    <ProgressSpinner />
+                </template>
+            </Suspense>
+        </SplitterPanel>
+        <SplitterPanel
+            :size="66"
+            :min-size="25"
+            :style="{
+                margin: '1rem 0rem 4rem 1rem',
+                overflowY: 'auto',
+                paddingRight: '4rem',
+            }"
+        >
+            <component
+                :is="panel"
+                :key="displayedRow?.id ?? routes.splash"
+            />
+        </SplitterPanel>
+    </Splitter>
+</template>

--- a/arches_references/src/arches_references/components/MainSplitter.vue
+++ b/arches_references/src/arches_references/components/MainSplitter.vue
@@ -5,7 +5,8 @@ import ProgressSpinner from "primevue/progressspinner";
 import Splitter from "primevue/splitter";
 import SplitterPanel from "primevue/splitterpanel";
 
-import { displayedRowKey, routes } from "@/arches_references/constants.ts";
+import { displayedRowKey } from "@/arches_references/constants.ts";
+import { routeNames } from "@/arches_references/routes.ts";
 import { dataIsList } from "@/arches_references/utils.ts";
 import ControlledListSplash from "@/arches_references/components/misc/ControlledListSplash.vue";
 import ItemEditor from "@/arches_references/components/editor/ItemEditor.vue";
@@ -55,7 +56,7 @@ const panel = computed(() => {
         >
             <component
                 :is="panel"
-                :key="displayedRow?.id ?? routes.splash"
+                :key="displayedRow?.id ?? routeNames.splash"
             />
         </SplitterPanel>
     </Splitter>

--- a/arches_references/src/arches_references/components/tree/AddDeleteControls.vue
+++ b/arches_references/src/arches_references/components/tree/AddDeleteControls.vue
@@ -5,7 +5,6 @@ import { useGettext } from "vue3-gettext";
 import { useConfirm } from "primevue/useconfirm";
 import { useToast } from "primevue/usetoast";
 import Button from "primevue/button";
-import ConfirmDialog from "primevue/confirmdialog";
 import SplitButton from "primevue/splitbutton";
 
 import {
@@ -113,7 +112,6 @@ const createList = () => {
     };
 
     nextNewList.value = newList;
-    newListFormValue.value = "";
     newListCounter.value += 1;
 
     tree.value.push(listAsNode(newList, selectedLanguage.value));
@@ -261,29 +259,6 @@ await fetchListsAndPopulateTree();
         raised
         :severity="shouldUseContrast() ? CONTRAST : PRIMARY"
         @click="createList"
-    />
-    <ConfirmDialog
-        :draggable="false"
-        :pt="{
-            root: {
-                style: {
-                    fontSize: 'small',
-                },
-            },
-            header: {
-                style: {
-                    background: 'var(--p-navigation)',
-                    color: 'white',
-                    borderRadius: '1rem',
-                    marginBottom: '1rem',
-                },
-            },
-            title: {
-                style: {
-                    fontWeight: 800,
-                },
-            },
-        }"
     />
     <SplitButton
         class="list-button"

--- a/arches_references/src/arches_references/components/tree/ListTree.vue
+++ b/arches_references/src/arches_references/components/tree/ListTree.vue
@@ -7,9 +7,9 @@ import Tree from "primevue/tree";
 
 import {
     displayedRowKey,
-    routes,
     selectedLanguageKey,
 } from "@/arches_references/constants.ts";
+import { routeNames } from "@/arches_references/routes.ts";
 import {
     bestLabel,
     findNodeInTree,
@@ -77,12 +77,12 @@ watch(
 );
 const navigate = (newRoute: RouteLocationNormalizedLoadedGeneric) => {
     switch (newRoute.name) {
-        case routes.splash:
+        case routeNames.splash:
             setDisplayedRow(null);
             expandedKeys.value = {};
             selectedKeys.value = {};
             break;
-        case routes.list: {
+        case routeNames.list: {
             if (!tree.value.length) {
                 return;
             }
@@ -101,7 +101,7 @@ const navigate = (newRoute: RouteLocationNormalizedLoadedGeneric) => {
             }
             break;
         }
-        case routes.item: {
+        case routeNames.item: {
             if (!tree.value.length) {
                 return;
             }

--- a/arches_references/src/arches_references/components/tree/ListTree.vue
+++ b/arches_references/src/arches_references/components/tree/ListTree.vue
@@ -58,6 +58,10 @@ const { setDisplayedRow } = inject(displayedRowKey) as unknown as {
 };
 
 const updateSelectedAndExpanded = (node: TreeNode) => {
+    if (isMultiSelecting.value || movingItem.value?.key) {
+        return;
+    }
+
     setDisplayedRow(node.data);
     expandedKeys.value = {
         ...expandedKeys.value,
@@ -169,7 +173,7 @@ const ptNodeContent = ({ instance }: TreePassThroughMethodOptions) => {
 <template>
     <ListTreeControls
         :key="refetcher"
-        v-model="tree"
+        v-model:tree="tree"
         v-model:rerender-tree="rerenderTree"
         v-model:expanded-keys="expandedKeys"
         v-model:selected-keys="selectedKeys"

--- a/arches_references/src/arches_references/components/tree/ListTree.vue
+++ b/arches_references/src/arches_references/components/tree/ListTree.vue
@@ -65,16 +65,7 @@ const { setDisplayedRow } = inject(displayedRowKey) as unknown as {
 };
 
 const route = useRoute();
-watch(
-    [
-        () => {
-            return { ...route };
-        },
-    ],
-    ([newRoute]) => {
-        navigate(newRoute);
-    },
-);
+
 const navigate = (newRoute: RouteLocationNormalizedLoadedGeneric) => {
     switch (newRoute.name) {
         case routeNames.splash:
@@ -129,6 +120,18 @@ const navigate = (newRoute: RouteLocationNormalizedLoadedGeneric) => {
         }
     }
 };
+
+// React to route changes.
+watch(
+    [
+        () => {
+            return { ...route };
+        },
+    ],
+    ([newRoute]) => {
+        navigate(newRoute);
+    },
+);
 
 // Navigate on initial load of the tree.
 watch(

--- a/arches_references/src/arches_references/components/tree/ListTreeControls.vue
+++ b/arches_references/src/arches_references/components/tree/ListTreeControls.vue
@@ -1,17 +1,11 @@
 <script setup lang="ts">
-import { inject, watch } from "vue";
-import { useRoute } from "vue-router";
-
-import { displayedRowKey, routes } from "@/arches_references/constants.ts";
-import { findNodeInTree } from "@/arches_references/utils.ts";
 import ActionBanner from "@/arches_references/components/tree/ActionBanner.vue";
 import AddDeleteControls from "@/arches_references/components/tree/AddDeleteControls.vue";
 import PresentationControls from "@/arches_references/components/tree/PresentationControls.vue";
 
-import type { RouteLocationNormalizedLoadedGeneric } from "vue-router";
 import type { TreeExpandedKeys, TreeSelectionKeys } from "primevue/tree";
 import type { TreeNode } from "primevue/treenode";
-import type { ControlledList, RowSetter } from "@/arches_references/types";
+import type { ControlledList } from "@/arches_references/types";
 
 const controlledListItemsTree = defineModel<TreeNode[]>("tree", {
     required: true,
@@ -32,75 +26,6 @@ const newListFormValue = defineModel<string>("newListFormValue", {
     required: true,
 });
 
-const { setDisplayedRow } = inject(displayedRowKey) as unknown as {
-    setDisplayedRow: RowSetter;
-};
-const route = useRoute();
-watch(
-    [
-        () => {
-            return { ...route };
-        },
-    ],
-    ([newRoute]) => {
-        navigate(newRoute);
-    },
-);
-const navigate = (newRoute: RouteLocationNormalizedLoadedGeneric) => {
-    switch (newRoute.name) {
-        case routes.splash:
-            setDisplayedRow(null);
-            expandedKeys.value = {};
-            selectedKeys.value = {};
-            break;
-        case routes.list: {
-            if (!controlledListItemsTree.value.length) {
-                return;
-            }
-            const list = controlledListItemsTree.value.find(
-                (node) => node.data.id === newRoute.params.id,
-            );
-            if (list) {
-                setDisplayedRow(list.data);
-                expandedKeys.value = {
-                    ...expandedKeys.value,
-                    [list.data.id]: true,
-                };
-                selectedKeys.value = { [list.data.id]: true };
-            } else {
-                setDisplayedRow(null);
-            }
-            break;
-        }
-        case routes.item: {
-            if (!controlledListItemsTree.value.length) {
-                return;
-            }
-            const { found, path } = findNodeInTree(
-                controlledListItemsTree.value,
-                newRoute.params.id as string,
-            );
-            if (found) {
-                setDisplayedRow(found.data);
-                const itemsToExpandIds = path.map(
-                    (itemInPath: TreeNode) => itemInPath.key,
-                );
-                expandedKeys.value = {
-                    ...expandedKeys.value,
-                    ...Object.fromEntries(
-                        [
-                            found.data.controlled_list_id,
-                            ...itemsToExpandIds,
-                        ].map((x) => [x, true]),
-                    ),
-                };
-                selectedKeys.value = { [found.data.id]: true };
-            }
-            break;
-        }
-    }
-};
-
 const expandAll = () => {
     for (const node of controlledListItemsTree.value) {
         expandNode(node);
@@ -120,15 +45,6 @@ const expandNode = (node: TreeNode) => {
         }
     }
 };
-
-// Navigate on initial load of the tree.
-watch(
-    controlledListItemsTree,
-    () => {
-        navigate(route);
-    },
-    { once: true },
-);
 </script>
 
 <template>

--- a/arches_references/src/arches_references/components/tree/ListTreeControls.vue
+++ b/arches_references/src/arches_references/components/tree/ListTreeControls.vue
@@ -1,13 +1,21 @@
 <script setup lang="ts">
+import { inject, watch } from "vue";
+import { useRoute } from "vue-router";
+
+import { displayedRowKey, routes } from "@/arches_references/constants.ts";
+import { findNodeInTree } from "@/arches_references/utils.ts";
 import ActionBanner from "@/arches_references/components/tree/ActionBanner.vue";
 import AddDeleteControls from "@/arches_references/components/tree/AddDeleteControls.vue";
 import PresentationControls from "@/arches_references/components/tree/PresentationControls.vue";
 
+import type { RouteLocationNormalizedLoadedGeneric } from "vue-router";
 import type { TreeExpandedKeys, TreeSelectionKeys } from "primevue/tree";
 import type { TreeNode } from "primevue/treenode";
-import type { ControlledList } from "@/arches_references/types";
+import type { ControlledList, RowSetter } from "@/arches_references/types";
 
-const controlledListItemsTree = defineModel<TreeNode[]>({ required: true });
+const controlledListItemsTree = defineModel<TreeNode[]>("tree", {
+    required: true,
+});
 const rerenderTree = defineModel<number>("rerenderTree", { required: true });
 const expandedKeys = defineModel<TreeExpandedKeys>("expandedKeys", {
     required: true,
@@ -23,6 +31,75 @@ const nextNewList = defineModel<ControlledList>("nextNewList");
 const newListFormValue = defineModel<string>("newListFormValue", {
     required: true,
 });
+
+const { setDisplayedRow } = inject(displayedRowKey) as unknown as {
+    setDisplayedRow: RowSetter;
+};
+const route = useRoute();
+watch(
+    [
+        () => {
+            return { ...route };
+        },
+    ],
+    ([newRoute]) => {
+        navigate(newRoute);
+    },
+);
+const navigate = (newRoute: RouteLocationNormalizedLoadedGeneric) => {
+    switch (newRoute.name) {
+        case routes.splash:
+            setDisplayedRow(null);
+            expandedKeys.value = {};
+            selectedKeys.value = {};
+            break;
+        case routes.list: {
+            if (!controlledListItemsTree.value.length) {
+                return;
+            }
+            const list = controlledListItemsTree.value.find(
+                (node) => node.data.id === newRoute.params.id,
+            );
+            if (list) {
+                setDisplayedRow(list.data);
+                expandedKeys.value = {
+                    ...expandedKeys.value,
+                    [list.data.id]: true,
+                };
+                selectedKeys.value = { [list.data.id]: true };
+            } else {
+                setDisplayedRow(null);
+            }
+            break;
+        }
+        case routes.item: {
+            if (!controlledListItemsTree.value.length) {
+                return;
+            }
+            const { found, path } = findNodeInTree(
+                controlledListItemsTree.value,
+                newRoute.params.id as string,
+            );
+            if (found) {
+                setDisplayedRow(found.data);
+                const itemsToExpandIds = path.map(
+                    (itemInPath: TreeNode) => itemInPath.key,
+                );
+                expandedKeys.value = {
+                    ...expandedKeys.value,
+                    ...Object.fromEntries(
+                        [
+                            found.data.controlled_list_id,
+                            ...itemsToExpandIds,
+                        ].map((x) => [x, true]),
+                    ),
+                };
+                selectedKeys.value = { [found.data.id]: true };
+            }
+            break;
+        }
+    }
+};
 
 const expandAll = () => {
     for (const node of controlledListItemsTree.value) {
@@ -43,6 +120,15 @@ const expandNode = (node: TreeNode) => {
         }
     }
 };
+
+// Navigate on initial load of the tree.
+watch(
+    controlledListItemsTree,
+    () => {
+        navigate(route);
+    },
+    { once: true },
+);
 </script>
 
 <template>

--- a/arches_references/src/arches_references/components/tree/MoveRow.vue
+++ b/arches_references/src/arches_references/components/tree/MoveRow.vue
@@ -69,9 +69,6 @@ const selectedKeys = defineModel<TreeSelectionKeys>("selectedKeys", {
 });
 const movingItem = defineModel<TreeNode>("movingItem");
 const nextNewItem = defineModel<ControlledListItem>("nextNewItem");
-const newLabelFormValue = defineModel<string>("newLabelFormValue", {
-    required: true,
-});
 const newLabelCounter = ref(1);
 const shouldRefocusUpArrow = ref(false);
 const shouldRefocusDownArrow = ref(false);
@@ -83,8 +80,8 @@ watch(displayedRow, () => {
 
 const isFirstItem = (item: ControlledListItem) => {
     const siblings: TreeNode[] = item.parent_id
-        ? findNodeInTree(tree.value, item.parent_id).data.children
-        : findNodeInTree(tree.value, item.list_id).data.items;
+        ? findNodeInTree(tree.value, item.parent_id).found!.data.children
+        : findNodeInTree(tree.value, item.list_id).found!.data.items;
     if (!siblings.length) {
         throw new Error();
     }
@@ -93,8 +90,8 @@ const isFirstItem = (item: ControlledListItem) => {
 
 const isLastItem = (item: ControlledListItem) => {
     const siblings: TreeNode[] = item.parent_id
-        ? findNodeInTree(tree.value, item.parent_id).data.children
-        : findNodeInTree(tree.value, item.list_id).data.items;
+        ? findNodeInTree(tree.value, item.parent_id).found!.data.children
+        : findNodeInTree(tree.value, item.list_id).found!.data.items;
     if (!siblings.length) {
         throw new Error();
     }
@@ -113,7 +110,7 @@ const setMovingItem = (node: TreeNode) => {
             ),
         ],
         node.key,
-    );
+    ).found;
 };
 
 const addItem = (parent: TreeNode) => {
@@ -139,7 +136,6 @@ const addItem = (parent: TreeNode) => {
     };
 
     nextNewItem.value = newItem;
-    newLabelFormValue.value = "";
     newLabelCounter.value += 1;
 
     parent.children!.push(itemAsNode(newItem, selectedLanguage.value));
@@ -153,13 +149,15 @@ const addItem = (parent: TreeNode) => {
 };
 
 const reorder = async (item: ControlledListItem, up: boolean) => {
-    const list: ControlledList = findNodeInTree(tree.value, item.list_id).data;
+    const list: ControlledList = findNodeInTree(tree.value, item.list_id).found!
+        .data;
 
     let siblings: ControlledListItem[];
     if (item.parent_id) {
-        siblings = findNodeInTree(tree.value, item.parent_id).children!.map(
-            (child: TreeNode) => child.data,
-        );
+        siblings = findNodeInTree(
+            tree.value,
+            item.parent_id,
+        ).found!.children!.map((child: TreeNode) => child.data);
     } else {
         siblings = list.items;
     }

--- a/arches_references/src/arches_references/components/tree/TreeRow.vue
+++ b/arches_references/src/arches_references/components/tree/TreeRow.vue
@@ -138,7 +138,7 @@ const setParent = async (parentNode: TreeNode) => {
         siblings.push(item);
     } else {
         item.parent_id = parentNode.key;
-        list = findNodeInTree(tree.value, item.list_id).data;
+        list = findNodeInTree(tree.value, item.list_id).found!.data;
         siblings = parentNode.data.children;
         siblings.push(item);
     }
@@ -213,7 +213,11 @@ const acceptNewItemShortcutEntry = async () => {
     const parent = findNodeInTree(
         tree.value,
         newItem.parent_id ?? newItem.list_id,
-    );
+    ).found;
+    if (!parent) {
+        throw new Error();
+    }
+
     parent.children = [
         ...parent.children!.filter((child: TreeNode) => !dataIsNew(child.data)),
         itemAsNode(newItem, selectedLanguage.value),
@@ -226,6 +230,7 @@ const acceptNewItemShortcutEntry = async () => {
 
     selectedKeys.value = { [newItem.id]: true };
     setDisplayedRow(newItem);
+    newLabelFormValue.value = "";
 };
 
 const triggerAcceptNewItemShortcut = () => {
@@ -259,6 +264,7 @@ const acceptNewListShortcutEntry = async () => {
     ];
     selectedKeys.value = { [newList.id]: true };
     setDisplayedRow(newList);
+    newLabelFormValue.value = "";
 };
 </script>
 
@@ -332,7 +338,6 @@ const acceptNewListShortcutEntry = async () => {
                 v-model:selected-keys="selectedKeys"
                 v-model:moving-item="movingItem"
                 v-model:next-new-item="nextNewItem"
-                v-model:new-label-form-value="newLabelFormValue"
                 :node
                 :move-labels
             />

--- a/arches_references/src/arches_references/constants.ts
+++ b/arches_references/src/arches_references/constants.ts
@@ -26,12 +26,6 @@ export const SECONDARY = "secondary";
 export const SUCCESS = "success";
 export const DEFAULT_ERROR_TOAST_LIFE = 8000;
 
-export const routes = {
-    splash: "splash",
-    list: "list",
-    item: "item",
-};
-
 // Django model choices
 export const METADATA_CHOICES = {
     title: "title",

--- a/arches_references/src/arches_references/constants.ts
+++ b/arches_references/src/arches_references/constants.ts
@@ -26,6 +26,12 @@ export const SECONDARY = "secondary";
 export const SUCCESS = "success";
 export const DEFAULT_ERROR_TOAST_LIFE = 8000;
 
+export const routes = {
+    splash: "splash",
+    list: "list",
+    item: "item",
+};
+
 // Django model choices
 export const METADATA_CHOICES = {
     title: "title",

--- a/arches_references/src/arches_references/plugins/ControlledListManager.vue
+++ b/arches_references/src/arches_references/plugins/ControlledListManager.vue
@@ -1,17 +1,5 @@
-<script setup lang="ts">
-import Toast from "primevue/toast";
-
-import ControlledListsMain from "@/arches_references/components/ControlledListsMain.vue";
-</script>
-
 <template>
-    <!-- Subtract size of arches toolbars -->
-    <div style="width: calc(100vw - 50px); height: calc(100vh - 50px)">
-        <div style="height: 100%">
-            <ControlledListsMain />
-        </div>
-    </div>
-    <Toast />
+    <RouterView />
 </template>
 
 <style scoped>

--- a/arches_references/src/arches_references/plugins/ControlledListManager.vue
+++ b/arches_references/src/arches_references/plugins/ControlledListManager.vue
@@ -1,19 +1,3 @@
 <template>
     <RouterView />
 </template>
-
-<style scoped>
-:deep(h1, h5, h6) {
-    font-weight: 600;
-}
-
-:deep(h2, h3) {
-    font-weight: 600;
-    font-size: 1.6rem;
-}
-
-:deep(h4) {
-    font-weight: 600;
-    font-size: 1.33rem;
-}
-</style>

--- a/arches_references/src/arches_references/routes.ts
+++ b/arches_references/src/arches_references/routes.ts
@@ -1,0 +1,25 @@
+import ControlledListsMain from "@/arches_references/components/ControlledListsMain.vue";
+
+export const routes = [
+    {
+        path: "/plugins/controlled-list-manager",
+        name: "splash",
+        component: ControlledListsMain,
+    },
+    {
+        path: "/plugins/controlled-list-manager/list/:id",
+        name: "list",
+        component: ControlledListsMain,
+    },
+    {
+        path: "/plugins/controlled-list-manager/item/:id",
+        name: "item",
+        component: ControlledListsMain,
+    },
+];
+
+export const routeNames = {
+    splash: "splash",
+    list: "list",
+    item: "item",
+};

--- a/arches_references/src/arches_references/utils.ts
+++ b/arches_references/src/arches_references/utils.ts
@@ -53,26 +53,36 @@ export const languageNameFromCode = (code: string) => {
     return arches.languages.find((lang: Language) => lang.code === code).name;
 };
 
-export const findNodeInTree = (tree: TreeNode[], itemId: string) => {
+export const findNodeInTree = (
+    tree: TreeNode[],
+    itemId: string,
+): {
+    found: TreeNode | undefined;
+    path: TreeNode[];
+} => {
+    const path: TreeNode[] = [];
+
     function recurse(items: TreeNode[]): TreeNode | undefined {
         for (const item of items) {
             if (item.data.id === itemId) {
                 return item;
             }
             for (const child of item.items ?? item.children) {
-                const maybeFound = recurse([child]);
-                if (maybeFound) {
-                    return maybeFound;
+                const found = recurse([child]);
+                if (found) {
+                    path.push(item);
+                    return found;
                 }
             }
         }
     }
 
-    const result = recurse(tree);
-    if (!result) {
+    const found = recurse(tree);
+    if (!found) {
         throw new Error();
     }
-    return result;
+
+    return { found, path };
 };
 
 // Shapers

--- a/arches_references/urls.py
+++ b/arches_references/urls.py
@@ -13,50 +13,50 @@ from arches_references.views import (
 )
 
 urlpatterns = [
-    path("api/controlled_lists/", ListsView.as_view(), name="controlled_lists"),
+    path("api/controlled_lists", ListsView.as_view(), name="controlled_lists"),
     path(
-        "api/controlled_list/<uuid:list_id>/",
+        "api/controlled_list/<uuid:list_id>",
         ListView.as_view(),
         name="controlled_list",
     ),
-    path("api/controlled_list/", ListView.as_view(), name="controlled_list_add"),
+    path("api/controlled_list", ListView.as_view(), name="controlled_list_add"),
     path(
-        "api/controlled_list_item/<uuid:item_id>/",
+        "api/controlled_list_item/<uuid:item_id>",
         ListItemView.as_view(),
         name="controlled_list_item",
     ),
     path(
-        "api/controlled_list_item/",
+        "api/controlled_list_item",
         ListItemView.as_view(),
         name="controlled_list_item_add",
     ),
     path(
-        "api/controlled_list_item_value/<uuid:value_id>/",
+        "api/controlled_list_item_value/<uuid:value_id>",
         ListItemValueView.as_view(),
         name="controlled_list_item_value",
     ),
     path(
-        "api/controlled_list_item_value/",
+        "api/controlled_list_item_value",
         ListItemValueView.as_view(),
         name="controlled_list_item_value_add",
     ),
     path(
-        "api/controlled_list_item_image/<uuid:image_id>/",
+        "api/controlled_list_item_image/<uuid:image_id>",
         ListItemImageView.as_view(),
         name="controlled_list_item_image",
     ),
     path(
-        "api/controlled_list_item_image/",
+        "api/controlled_list_item_image",
         ListItemImageView.as_view(),
         name="controlled_list_item_image_add",
     ),
     path(
-        "api/controlled_list_item_image_metadata/<uuid:metadata_id>/",
+        "api/controlled_list_item_image_metadata/<uuid:metadata_id>",
         ListItemImageMetadataView.as_view(),
         name="controlled_list_item_image_metadata",
     ),
     path(
-        "api/controlled_list_item_image_metadata/",
+        "api/controlled_list_item_image_metadata",
         ListItemImageMetadataView.as_view(),
         name="controlled_list_item_image_metadata_add",
     ),

--- a/arches_references/views.py
+++ b/arches_references/views.py
@@ -1,13 +1,12 @@
-import logging
 from http import HTTPStatus
 from uuid import UUID
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import Max
-from django.views.generic import View
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
+from django.views.generic import View
 
 from arches.app.models.utils import field_names
 from arches.app.utils.betterJSONSerializer import JSONDeserializer
@@ -24,8 +23,6 @@ from arches_references.models import (
     ListItemValue,
     NodeProxy,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def _prefetch_terms(request):
@@ -90,7 +87,7 @@ class ListsView(APIBase):
 @method_decorator(
     group_required("RDM Administrator", raise_exception=True), name="dispatch"
 )
-class ListView(View):
+class ListView(APIBase):
     def get(self, request, list_id):
         """Returns either a flat representation (?flat=true) or a tree (default)."""
         try:
@@ -176,7 +173,7 @@ class ListView(View):
 @method_decorator(
     group_required("RDM Administrator", raise_exception=True), name="dispatch"
 )
-class ListItemView(View):
+class ListItemView(APIBase):
     def post(self, request):
         data = JSONDeserializer().deserialize(request.body)
         try:
@@ -247,7 +244,7 @@ class ListItemView(View):
 @method_decorator(
     group_required("RDM Administrator", raise_exception=True), name="dispatch"
 )
-class ListItemValueView(View):
+class ListItemValueView(APIBase):
     def post(self, request):
         data = JSONDeserializer().deserialize(request.body)
         value = ListItemValue(**data)
@@ -301,7 +298,7 @@ class ListItemValueView(View):
 @method_decorator(
     group_required("RDM Administrator", raise_exception=True), name="dispatch"
 )
-class ListItemImageView(View):
+class ListItemImageView(APIBase):
     def post(self, request):
         uploaded_file = request.FILES["item_image"]
         img = ListItemImage(
@@ -328,7 +325,7 @@ class ListItemImageView(View):
 @method_decorator(
     group_required("RDM Administrator", raise_exception=True), name="dispatch"
 )
-class ListItemImageMetadataView(View):
+class ListItemImageMetadataView(APIBase):
     def post(self, request):
         data = JSONDeserializer().deserialize(request.body)
         data.pop("metadata_label", None)

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
             "name": "arches_references",
             "license": "AGPL-3.0-only",
             "dependencies": {
-                "arches": "archesproject/arches#dev/7.6.x"
+                "arches": "archesproject/arches#dev/7.6.x",
+                "vue-router": "^4.4.0"
             },
             "devDependencies": {
                 "arches-dev-dependencies": "archesproject/arches-dev-dependencies#dev/7.6.x"
@@ -5545,6 +5546,11 @@
                 "de-indent": "^1.0.2",
                 "he": "^1.2.0"
             }
+        },
+        "node_modules/@vue/devtools-api": {
+            "version": "6.6.3",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.3.tgz",
+            "integrity": "sha512-0MiMsFma/HqA6g3KLKn+AGpL1kgKhFWszC9U29NfpWK5LE7bjeXxySWJrOJ77hBz+TBrBQ7o4QJqbPbqbs8rJw=="
         },
         "node_modules/@vue/language-core": {
             "version": "2.0.29",
@@ -16713,6 +16719,20 @@
                 "vue": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/vue-router": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.4.0.tgz",
+            "integrity": "sha512-HB+t2p611aIZraV2aPSRNXf0Z/oLZFrlygJm+sZbdJaW6lcFqEDQwnzUBXn+DApw+/QzDU/I9TeWx9izEjTmsA==",
+            "dependencies": {
+                "@vue/devtools-api": "^6.5.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/posva"
+            },
+            "peerDependencies": {
+                "vue": "^3.2.0"
             }
         },
         "node_modules/vue-template-compiler": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,11 @@
             "name": "arches_references",
             "license": "AGPL-3.0-only",
             "dependencies": {
-                "arches": "archesproject/arches#dev/7.6.x",
+                "arches": "archesproject/arches#dev/8.0.x",
                 "vue-router": "^4.4.0"
             },
             "devDependencies": {
-                "arches-dev-dependencies": "archesproject/arches-dev-dependencies#dev/7.6.x"
+                "arches-dev-dependencies": "archesproject/arches-dev-dependencies#dev/8.0.x"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -6029,8 +6029,8 @@
             }
         },
         "node_modules/arches": {
-            "version": "7.6.0",
-            "resolved": "git+ssh://git@github.com/archesproject/arches.git#017862edff660c4a7bb58c4d5e9c9e969ab1008e",
+            "version": "8.0.0",
+            "resolved": "git+ssh://git@github.com/archesproject/arches.git#d093f8f386ccb50a80709b13dc5802618cf262a4",
             "dependencies": {
                 "@babel/runtime": "^7.17.2",
                 "@mapbox/geojson-extent": "~1.0.1",
@@ -6098,8 +6098,8 @@
             }
         },
         "node_modules/arches-dev-dependencies": {
-            "version": "7.6.0",
-            "resolved": "git+ssh://git@github.com/archesproject/arches-dev-dependencies.git#d75232c50957237421aece034456b785ad05bb85",
+            "version": "8.0.0",
+            "resolved": "git+ssh://git@github.com/archesproject/arches-dev-dependencies.git#c5d4097acc341980e327d4cb12534a3a2765107f",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.24.4",
@@ -16722,11 +16722,11 @@
             }
         },
         "node_modules/vue-router": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.4.0.tgz",
-            "integrity": "sha512-HB+t2p611aIZraV2aPSRNXf0Z/oLZFrlygJm+sZbdJaW6lcFqEDQwnzUBXn+DApw+/QzDU/I9TeWx9izEjTmsA==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.4.3.tgz",
+            "integrity": "sha512-sv6wmNKx2j3aqJQDMxLFzs/u/mjA9Z5LCgy6BE0f7yFWMjrPLnS/sPNn8ARY/FXw6byV18EFutn5lTO6+UsV5A==",
             "dependencies": {
-                "@vue/devtools-api": "^6.5.1"
+                "@vue/devtools-api": "^6.6.3"
             },
             "funding": {
                 "url": "https://github.com/sponsors/posva"

--- a/package.json
+++ b/package.json
@@ -18,17 +18,17 @@
         "vitest": "vitest --run --coverage"
     },
     "dependencies": {
-        "arches": "archesproject/arches#dev/7.6.x"
+        "arches": "archesproject/arches#dev/7.6.x",
+        "vue-router": "^4.4.0"
     },
     "devDependencies": {
         "arches-dev-dependencies": "archesproject/arches-dev-dependencies#dev/7.6.x"
     },
-    "nodeModulesPaths": {
-    },
+    "nodeModulesPaths": {},
     "overrides": {
         "moment-timezone": "^0.5.45",
         "nomnom": "npm:@gerhobbelt/nomnom",
-        "rimraf": "^5.0.7", 
+        "rimraf": "^5.0.7",
         "underscore": "^1.13.6"
     }
 }

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
         "vitest": "vitest --run --coverage"
     },
     "dependencies": {
-        "arches": "archesproject/arches#dev/7.6.x",
+        "arches": "archesproject/arches#dev/8.0.x",
         "vue-router": "^4.4.0"
     },
     "devDependencies": {
-        "arches-dev-dependencies": "archesproject/arches-dev-dependencies#dev/7.6.x"
+        "arches-dev-dependencies": "archesproject/arches-dev-dependencies#dev/8.0.x"
     },
     "nodeModulesPaths": {},
     "overrides": {


### PR DESCRIPTION
Natural forward and back navigation is now supported when interacting with lists & items. Allows resolving the default item URIs generated in #17.

- Isolate component that renders the router (was getting double toast / confirm popups)
- Remove trailing slashes from controlled lists routes
- Move name entry field reset to more logical place

Closes #4