### PR TITLE
Adjust github action template

### DIFF
--- a/.github/actions/build-and-test-branch/action.yml
+++ b/.github/actions/build-and-test-branch/action.yml
@@ -33,7 +33,7 @@ runs:
 
     - name: Ensure frontend configuration files exist
       run: |
-        python manage.py check
+        python manage.py check --tag=compatibility
       shell: bash
 
     - name: Install Arches applications
@@ -74,7 +74,7 @@ runs:
 
     - name: Check for missing migrations
       run: |
-        python manage.py makemigrations --check
+        python manage.py makemigrations --check --skip-checks
       shell: bash
 
     - name: Ensure previous Python coverage data is erased


### PR DESCRIPTION
Cope with changes to the github action template merged in #10079.

### Rationale
The github action only sets up a test db, not a real db. The system check in archesproject/arches#10079 expects there to be a real db, so we need to skip system checks in a couple places where we're not intending to run them. The first place is just there to generate the frontend config file.