### PR TITLE
Style cleanups

### DIFF
--- a/arches_references/media/js/views/components/plugins/controlled-list-manager.js
+++ b/arches_references/media/js/views/components/plugins/controlled-list-manager.js
@@ -16,7 +16,7 @@ const router = createRouter({
 
 const ControlledListsPreset = definePreset(ArchesPreset, {
     semantic: {
-        iconSize: 'small',
+        iconSize: '1.2rem',
     },
     components: {
         button: {

--- a/arches_references/src/arches_references/components/ControlledListsMain.vue
+++ b/arches_references/src/arches_references/components/ControlledListsMain.vue
@@ -54,8 +54,7 @@ provide(systemLanguageKey, systemLanguage);
 </script>
 
 <template>
-    <!-- Subtract size of arches toolbars -->
-    <div style="width: calc(100vw - 50px); height: calc(100vh - 50px)">
+    <div style="width: 100vw; height: 100vh; padding-bottom: 1.75rem">
         <div class="list-editor-container">
             <ListHeader />
             <MainSplitter />

--- a/arches_references/src/arches_references/components/ControlledListsMain.vue
+++ b/arches_references/src/arches_references/components/ControlledListsMain.vue
@@ -54,7 +54,7 @@ provide(systemLanguageKey, systemLanguage);
 </script>
 
 <template>
-    <div style="width: 100vw; height: 100vh; padding-bottom: 1.75rem">
+    <div style="width: 100%; height: 100vh; padding-bottom: 1.75rem">
         <div class="list-editor-container">
             <ListHeader />
             <MainSplitter />

--- a/arches_references/src/arches_references/components/ControlledListsMain.vue
+++ b/arches_references/src/arches_references/components/ControlledListsMain.vue
@@ -54,7 +54,7 @@ provide(systemLanguageKey, systemLanguage);
 </script>
 
 <template>
-    <div style="width: 100%; height: 100vh; padding-bottom: 1.75rem">
+    <div style="height: 100vh; padding-bottom: 2.5rem">
         <div class="list-editor-container">
             <ListHeader />
             <MainSplitter />

--- a/arches_references/src/arches_references/components/MainSplitter.vue
+++ b/arches_references/src/arches_references/components/MainSplitter.vue
@@ -34,7 +34,7 @@ const panel = computed(() => {
 <template>
     <Splitter style="height: 100%; overflow: hidden">
         <SplitterPanel
-            :size="34"
+            :size="30"
             :min-size="25"
             style="display: flex; flex-direction: column"
         >
@@ -46,12 +46,12 @@ const panel = computed(() => {
             </Suspense>
         </SplitterPanel>
         <SplitterPanel
-            :size="66"
+            :size="70"
             :min-size="25"
             :style="{
                 margin: '1rem 0rem 4rem 1rem',
                 overflowY: 'auto',
-                paddingRight: '4rem',
+                paddingRight: '2rem',
             }"
         >
             <component

--- a/arches_references/src/arches_references/components/MainSplitter.vue
+++ b/arches_references/src/arches_references/components/MainSplitter.vue
@@ -32,7 +32,7 @@ const panel = computed(() => {
 </script>
 
 <template>
-    <Splitter style="height: 100%">
+    <Splitter style="height: 100%; overflow: hidden">
         <SplitterPanel
             :size="34"
             :min-size="25"

--- a/arches_references/src/arches_references/components/editor/ImageMetadata.vue
+++ b/arches_references/src/arches_references/components/editor/ImageMetadata.vue
@@ -326,7 +326,7 @@ const focusInput = () => {
             </Column>
             <Column
                 :row-editor="true"
-                style="width: 5%; min-width: 6rem; text-align: center"
+                style="width: 5%; text-align: center; white-space: nowrap"
                 :pt="{
                     headerCell: { ariaLabel: $gettext('Row edit controls') },
                 }"

--- a/arches_references/src/arches_references/components/editor/ValueEditor.vue
+++ b/arches_references/src/arches_references/components/editor/ValueEditor.vue
@@ -352,7 +352,7 @@ const focusInput = () => {
             </Column>
             <Column
                 :row-editor="true"
-                style="width: 5%; min-width: 6rem; text-align: center"
+                style="width: 5%; text-align: center; white-space: nowrap"
                 :pt="{
                     headerCell: { ariaLabel: $gettext('Row edit controls') },
                 }"

--- a/arches_references/src/arches_references/components/tree/ListTree.vue
+++ b/arches_references/src/arches_references/components/tree/ListTree.vue
@@ -271,11 +271,6 @@ function lazyLabelLookup(node: TreeNode) {
                     style: { width: '100%', fontSize: 'small' },
                 },
             },
-            pcFilterIconContainer: {
-                root: {
-                    style: { display: 'flex' },
-                },
-            },
             wrapper: {
                 style: {
                     overflowY: 'auto',

--- a/arches_references/src/arches_references/components/tree/PresentationControls.vue
+++ b/arches_references/src/arches_references/components/tree/PresentationControls.vue
@@ -16,14 +16,18 @@ import { shouldUseContrast } from "@/arches_references/utils.ts";
 import type { Ref } from "vue";
 import type { Language } from "@/arches_vue_utils/types";
 
-const { $gettext } = useGettext();
-
-const selectedLanguage = inject(selectedLanguageKey) as Ref<Language>;
-
 const { expandAll, collapseAll } = defineProps<{
     expandAll: () => void;
     collapseAll: () => void;
 }>();
+
+let selectedLanguage: Ref<Language> | undefined;
+if (arches.languages) {
+    // arches-lingo reuses this component without this provided.
+    selectedLanguage = inject(selectedLanguageKey);
+}
+
+const { $gettext } = useGettext();
 </script>
 
 <template>

--- a/arches_references/src/arches_references/components/tree/PresentationControls.vue
+++ b/arches_references/src/arches_references/components/tree/PresentationControls.vue
@@ -44,7 +44,10 @@ const { expandAll, collapseAll } = defineProps<{
             :label="$gettext('Collapse all')"
             @click="collapseAll"
         />
-        <div style="display: flex; flex-grow: 1; justify-content: flex-end">
+        <div
+            v-if="arches.languages"
+            class="language-select"
+        >
             <span
                 id="languageSelectLabel"
                 style="
@@ -77,5 +80,11 @@ const { expandAll, collapseAll } = defineProps<{
 .secondary-button {
     height: 3rem;
     margin: 0.5rem;
+}
+
+.language-select {
+    display: flex;
+    flex-grow: 1;
+    justify-content: flex-end;
 }
 </style>

--- a/arches_references/templates/views/components/plugins/controlled-list-manager.htm
+++ b/arches_references/templates/views/components/plugins/controlled-list-manager.htm
@@ -1,1 +1,4 @@
-<div id="controlled-list-manager-mounting-point" style="font-family: 'Open Sans'"></div>
+<div
+    id="controlled-list-manager-mounting-point"
+    style="height: 100%; width: 100%; font-family: 'Open Sans'"
+></div>


### PR DESCRIPTION
- [Avoid rendering language picker if arches object is missing](https://github.com/archesproject/arches-references/commit/25fbef53fd9b37895d06343a75c7eb459432efe5)(important for lingo, which doesn't have `arches.languages`)
- [Avoid wrapping edit controls](https://github.com/archesproject/arches-references/commit/95261615d735f19af50037d20f8460628ba9aca4)
- [Improve position of filter icon](https://github.com/archesproject/arches-references/commit/df8ebb47c49a460ac67d8a896511d83ad1c65be8)
- [Hide injection of selected language under if](https://github.com/archesproject/arches-references/pull/56/commits/cfdf325d24c50973744a444c9303b3271119a16e) (lingo doesn't implement language selection)