### PR TITLE
Create dataclass for reference datatype and improve validation #45

### DIFF
--- a/arches_references/media/js/viewmodels/reference-select.js
+++ b/arches_references/media/js/viewmodels/reference-select.js
@@ -51,7 +51,7 @@ define([
                     const newItem = selection.map(uri => {
                         return {
                             "labels": NAME_LOOKUP[uri].labels,
-                            "listid": NAME_LOOKUP[uri]["listid"],
+                            "list_id": NAME_LOOKUP[uri]["list_id"],
                             "uri": uri
                         };
                     });
@@ -90,7 +90,7 @@ define([
                 processResults: function(data) {
                     const items = data.items; 
                     items.forEach(item => {
-                        item["listid"] = item.id;
+                        item["list_id"] = item.id;
                         item.id = item.uri;
                         item.disabled = item.guide;
                         item.labels = item.values.filter(val => self.isLabel(val));
@@ -111,7 +111,7 @@ define([
 
                 if (item.uri) {
                     const text = self.getPrefLabel(item.labels) || arches.translations.searching + '...';
-                    NAME_LOOKUP[item.uri] = {"prefLabel": text, "labels": item.labels, "listid": item.list_id};
+                    NAME_LOOKUP[item.uri] = {"prefLabel": text, "labels": item.labels, "list_id": item.list_id};
                     return indentation + text;
                 }
             },
@@ -132,7 +132,7 @@ define([
                         NAME_LOOKUP[value.uri] = {
                                 "prefLabel": self.getPrefLabel(value.labels),
                                 "labels": value.labels,
-                                "listid": value.listid 
+                                "list_id": value.list_id,
                             };
                     });
        

--- a/arches_references/models.py
+++ b/arches_references/models.py
@@ -215,7 +215,7 @@ class ListItem(models.Model):
         tile_value = {
             "uri": self.uri or self.generate_uri(),
             "labels": [label.serialize() for label in self.list_item_values.labels()],
-            "listid": str(self.list_id),
+            "list_id": str(self.list_id),
         }
         return tile_value
 

--- a/tests/reference_datatype_tests.py
+++ b/tests/reference_datatype_tests.py
@@ -64,6 +64,7 @@ class ReferenceDataTypeTests(TestCase):
                 {
                     "id": "e8676242-f0c7-4e3d-b031-fded4960cd86",
                     "language_id": "de",
+                    "list_item_id": str(uuid.uuid4()),
                     "valuetype_id": "prefLabel",
                 },
             ],
@@ -99,6 +100,7 @@ class ReferenceDataTypeTests(TestCase):
                         "value": "label",
                         "language_id": "en",
                         "valuetype_id": "prefLabel",
+                        "list_item_id": str(uuid.uuid4()),
                     },
                 ],
                 "list_id": "fd9508dc-2aab-4c46-85ae-dccce1200035",
@@ -120,6 +122,15 @@ class ReferenceDataTypeTests(TestCase):
         tile1.data[nodeid] = []
         reference.clean(tile1, nodeid)
         self.assertIsNone(tile1.data[nodeid])
+
+    def test_dataclass_roundtrip(self):
+        reference = DataTypeFactory().get_instance("reference")
+        list1_pk = str(List.objects.get(name="list1").pk)
+        config = {"controlledList": list1_pk}
+        tile_val = reference.transform_value_for_tile("label1-pref", **config)
+        materialized = reference.to_python(tile_val)
+        tile_val_reparsed = reference.transform_value_for_tile(materialized, **config)
+        self.assertEqual(tile_val_reparsed, tile_val)
 
     def test_transform_value_for_tile(self):
         reference = DataTypeFactory().get_instance("reference")

--- a/tests/reference_datatype_tests.py
+++ b/tests/reference_datatype_tests.py
@@ -95,6 +95,10 @@ class ReferenceDataTypeTests(TestCase):
         errors = reference.validate(value=[data, data], node=mock_node)
         self.assertEqual(len(errors), 1, errors)
 
+        # User error (missing arguments)
+        errors = reference.validate(value=[data])
+        self.assertEqual(len(errors), 1, errors)
+
     def test_tile_clean(self):
         reference = DataTypeFactory().get_instance("reference")
         nodeid = "72048cb3-adbc-11e6-9ccf-14109fd34195"


### PR DESCRIPTION
As #45 mentions, we didn't have validation against unexpected keys in the reference tile data, so that's how we ended up with `list_id` and `listid`.

We could roll our own solution for this, but I'm suggesting that one approach would be to just use python dataclasses for this so that we have one central place to define the expected keys. This made the validate() method much easier to rewrite. We could also make use of the `frozen` feature if we want immutable python objects later.

There's a bit of fiddliness around transforming error messages into something that can be localized, but if we like this pattern we can probably factor that out into something reusable with other datatypes.

Intended to be tested with the partner lingo PR: https://github.com/archesproject/arches-lingo/pull/208

Closes #45