### PR TITLE
disables reference widget autocomplete as backend is not functional

### DIFF
--- a/arches_controlled_lists/media/js/viewmodels/reference-select.js
+++ b/arches_controlled_lists/media/js/viewmodels/reference-select.js
@@ -77,6 +77,7 @@ export default function(params) {
 
     this.select2Config = {
         value: self.selectionValue,
+        minimumResultsForSearch: -1,
         clickBubble: true,
         multiple: this.multiple,
         closeOnSelect: true,


### PR DESCRIPTION
re: #138 #5
temporary fix for non-functional autocomplete in reference widget.  In the future this will need to be removed once there is backend support for filtering by input strings.