### PR TITLE
Fix ordering of installed apps so subclassed pkg command works

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,20 @@ For developer install instructions, see the [Developer Setup](#developer-setup-f
 
 1. If you don't already have an Arches project, you'll need to create one by following the instructions in the Arches [documentation](http://archesproject.org/documentation/).
 
-2. When your project is ready, add "django.contrib.postgres", "arches_querysets", "arches_component_lab", "arches_controlled_lists", and "pgtrigger" to INSTALLED_APPS **below** the name of your project:
+2. When your project is ready, make the following changes to INSTALLED_APPS:
+- Move *"my_project_name"* to the top
+- Add "arches_controlled_lists" **above** "arches"
+- Add "django.contrib.postgres", "arches_querysets", "arches_component_lab", and "pgtrigger" to the bottom of the tuple along with any other arches applications:
     ```
     INSTALLED_APPS = (
+        "my_project_name"
         ...
-        "my_project_name",
+        "arches_controlled_lists"
+        "arches"
+        ...
         "django.contrib.postgres",
         "arches_querysets",
         "arches_component_lab",
-        "arches_controlled_lists",
         "pgtrigger",
     )
     ```


### PR DESCRIPTION
Ordering of installed apps is important re. packages command and it's operations. `arches_controlled_lists` needs to be above `arches`