### PR TITLE
Adds utility to change base url

### DIFF
--- a/arches_controlled_lists/management/commands/controlled_lists.py
+++ b/arches_controlled_lists/management/commands/controlled_lists.py
@@ -40,6 +40,15 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
+            "-li",
+            "--lists",
+            action="store",
+            dest="lists",
+            default=False,
+            help="A comma separated list of the listids of the resources you would like to change the url base for.  If not provided, all controlled lists will be updated.",
+        )
+
+        parser.add_argument(
             "-co",
             "--collections",
             action="store",
@@ -119,7 +128,13 @@ class Command(BaseCommand):
         elif options["operation"] == "change_url_base":
             if not options["host"] or options["host"] is None:
                 raise CommandError("Please provide a target host")
-            self.bulk_change_url_base(target_hostname=options["host"])
+            if options["lists"]:
+                list_ids = options["lists"].split(",")
+            else:
+                list_ids = []
+            self.bulk_change_url_base(
+                target_hostname=options["host"], list_ids=list_ids
+            )
 
     def migrate_collections_to_controlled_lists(
         self,
@@ -317,11 +332,14 @@ class Command(BaseCommand):
             )
 
     # Replaces the base URL for all list items in all controlled lists
-    def bulk_change_url_base(self, target_hostname: str) -> str:
+    def bulk_change_url_base(self, target_hostname: str, list_ids: list) -> str:
         normalized_url = self._normalize_url(target_hostname)
         try:
             with transaction.atomic():
-                for list_item in ListItem.objects.all():
+                list_item_query = ListItem.objects.all()
+                if list_ids:
+                    list_item_query = list_item_query.filter(list_id__in=list_ids)
+                for list_item in list_item_query.all():
                     new_uri = self._replace_hostname(list_item.uri, normalized_url)
                     list_item.uri = new_uri
                     list_item.save()
@@ -334,14 +352,24 @@ class Command(BaseCommand):
     # Ensure that the URL has a scheme and is properly formatted
     def _normalize_url(self, url, default_scheme="https"):
         if not url.startswith("//") and "://" not in url:
-            url = f"//{url}"
+            url = f"{default_scheme}://{url.lstrip('/')}"
 
-        parts = urlsplit(url, scheme=default_scheme)
+        parts = urlsplit(url)
+
         scheme = parts.scheme or default_scheme
 
-        return urlunsplit(
-            (scheme, parts.netloc, parts.path, parts.query, parts.fragment)
-        )
+        if parts.port is not None:
+            is_http_default = scheme == "http" and parts.port == 80
+            is_https_default = scheme == "https" and parts.port == 443
+
+            if is_http_default or is_https_default:
+                netloc = parts.hostname
+            else:
+                netloc = parts.netloc
+        else:
+            netloc = parts.netloc
+
+        return urlunsplit((scheme, netloc, parts.path, parts.query, parts.fragment))
 
     # Replace the hostname in a given URL with the target hostname
     def _replace_hostname(self, url_string: str, target_hostname: str) -> str:
@@ -356,13 +384,8 @@ class Command(BaseCommand):
                 )
                 return url_string
 
-            port = parsed_url.port
-            if port:
-                new_netloc = f"{normalized_target.netloc}:{port}"
-                new_scheme = normalized_target.scheme
-            else:
-                new_netloc = normalized_target.netloc
-                new_scheme = normalized_target.scheme
+            new_netloc = normalized_target.netloc
+            new_scheme = normalized_target.scheme
 
             updated_url = urlunparse(
                 (

--- a/arches_controlled_lists/management/commands/controlled_lists.py
+++ b/arches_controlled_lists/management/commands/controlled_lists.py
@@ -359,12 +359,14 @@ class Command(BaseCommand):
             port = parsed_url.port
             if port:
                 new_netloc = f"{normalized_target.netloc}:{port}"
+                new_scheme = normalized_target.scheme
             else:
                 new_netloc = normalized_target.netloc
+                new_scheme = normalized_target.scheme
 
             updated_url = urlunparse(
                 (
-                    parsed_url.scheme,
+                    new_scheme,
                     new_netloc,
                     parsed_url.path,
                     parsed_url.params,

--- a/arches_controlled_lists/management/commands/controlled_lists.py
+++ b/arches_controlled_lists/management/commands/controlled_lists.py
@@ -1,3 +1,4 @@
+from urllib.parse import urlparse, urlunparse, urlsplit, urlunsplit
 from django.core.management.base import BaseCommand, CommandError
 from django.db import connection, models, transaction
 from django.db.models.expressions import CombinedExpression
@@ -14,7 +15,7 @@ from arches.app.models.models import (
     Value,
     Widget,
 )
-from arches_controlled_lists.models import List
+from arches_controlled_lists.models import List, ListItem
 
 
 class Command(BaseCommand):
@@ -33,6 +34,7 @@ class Command(BaseCommand):
             choices=[
                 "migrate_collections_to_controlled_lists",
                 "migrate_concept_nodes_to_reference_datatype",
+                "change_url_base",
             ],
             help="The operation to perform",
         )
@@ -114,6 +116,10 @@ class Command(BaseCommand):
             if not graph or graph is None:
                 raise CommandError("Please provide a graph id or slug")
             self.migrate_concept_nodes_to_reference_datatype(graph)
+        elif options["operation"] == "change_url_base":
+            if not options["host"] or options["host"] is None:
+                raise CommandError("Please provide a target host")
+            self.bulk_change_url_base(target_hostname=options["host"])
 
     def migrate_collections_to_controlled_lists(
         self,
@@ -309,3 +315,66 @@ class Command(BaseCommand):
                     source_graph.name
                 )
             )
+
+    # Replaces the base URL for all list items in all controlled lists
+    def bulk_change_url_base(self, target_hostname: str) -> str:
+        normalized_url = self._normalize_url(target_hostname)
+        try:
+            with transaction.atomic():
+                for list_item in ListItem.objects.all():
+                    new_uri = self._replace_hostname(list_item.uri, normalized_url)
+                    list_item.uri = new_uri
+                    list_item.save()
+        except Exception as e:
+            self.stderr.write(f"Could not change base url: {str(e)}")
+            return
+
+        self.stdout.write("Successfully changed URL base.")
+
+    # Ensure that the URL has a scheme and is properly formatted
+    def _normalize_url(self, url, default_scheme="https"):
+        if not url.startswith("//") and "://" not in url:
+            url = f"//{url}"
+
+        parts = urlsplit(url, scheme=default_scheme)
+        scheme = parts.scheme or default_scheme
+
+        return urlunsplit(
+            (scheme, parts.netloc, parts.path, parts.query, parts.fragment)
+        )
+
+    # Replace the hostname in a given URL with the target hostname
+    def _replace_hostname(self, url_string: str, target_hostname: str) -> str:
+        try:
+            normalized_target = urlparse(target_hostname)
+            parsed_url = urlparse(url_string)
+
+            # Should never happen - but abandon ship if it does
+            if not parsed_url.netloc:
+                print(
+                    f"Warning: Invalid URL format, missing network location: {url_string}"
+                )
+                return url_string
+
+            port = parsed_url.port
+            if port:
+                new_netloc = f"{normalized_target.netloc}:{port}"
+            else:
+                new_netloc = normalized_target.netloc
+
+            updated_url = urlunparse(
+                (
+                    parsed_url.scheme,
+                    new_netloc,
+                    parsed_url.path,
+                    parsed_url.params,
+                    parsed_url.query,
+                    parsed_url.fragment,
+                )
+            )
+
+            return updated_url
+
+        except Exception as e:
+            print(f"An error occurred while processing the URL: {e}")
+            return url_string

--- a/releases/1.1.0.md
+++ b/releases/1.1.0.md
@@ -2,4 +2,6 @@
 
 ### Major enhancements
 
+- Adds a utility to modify the base url for controlled list items.
+
 ### Additional highlights

--- a/tests/cli_tests.py
+++ b/tests/cli_tests.py
@@ -345,3 +345,108 @@ class MigrateConceptNodesToReferenceDatatypeTests(TestCase):
             stderr=output,
         )
         self.assertEqual(output.getvalue().strip(), expected_output)
+
+
+class ChangeUrlBaseTests(TestCase):
+
+    def setUp(self):
+        self.list = List.objects.create(name="Test List")
+        self.item1 = ListItem.objects.create(
+            list=self.list,
+            uri="http://localhost:8000/plugins/controlled-list-manager/item/item-1",
+            sortorder=0,
+        )
+        self.item2 = ListItem.objects.create(
+            list=self.list,
+            uri="http://localhost:8000/plugins/controlled-list-manager/item/item-2",
+            sortorder=1,
+        )
+        self.item3 = ListItem.objects.create(
+            list=self.list,
+            uri="http://localhost:8080/plugins/controlled-list-manager/item/item-3",
+            sortorder=2,
+        )
+
+    def test_change_url_base_all_lists(self):
+        output = io.StringIO()
+        management.call_command(
+            "controlled_lists",
+            operation="change_url_base",
+            host="https://example.com",
+            stdout=output,
+        )
+
+        self.item1.refresh_from_db()
+        self.item2.refresh_from_db()
+        self.item3.refresh_from_db()
+
+        self.assertEqual(
+            self.item1.uri,
+            "https://example.com/plugins/controlled-list-manager/item/item-1",
+        )
+        self.assertEqual(
+            self.item2.uri,
+            "https://example.com/plugins/controlled-list-manager/item/item-2",
+        )
+        self.assertEqual(
+            self.item3.uri,
+            "https://example.com/plugins/controlled-list-manager/item/item-3",
+        )
+        self.assertIn("Successfully changed URL base.", output.getvalue())
+
+    def test_change_url_base_specific_list(self):
+        second_list = List.objects.create(name="Second List")
+        second_item = ListItem.objects.create(
+            list=second_list,
+            uri="http://localhost:8000/plugins/controlled-list-manager/item/second-item",
+            sortorder=0,
+        )
+
+        output = io.StringIO()
+        management.call_command(
+            "controlled_lists",
+            operation="change_url_base",
+            host="https://production.org:443",
+            lists=str(second_list.id),
+            stdout=output,
+        )
+
+        second_item.refresh_from_db()
+
+        self.assertEqual(
+            self.item1.uri,
+            "http://localhost:8000/plugins/controlled-list-manager/item/item-1",
+        )
+
+        self.assertEqual(
+            second_item.uri,
+            "https://production.org/plugins/controlled-list-manager/item/second-item",
+        )
+
+    def test_change_url_base_preserves_port(self):
+        output = io.StringIO()
+        management.call_command(
+            "controlled_lists",
+            operation="change_url_base",
+            host="https://newdomain.com:8080",
+            stdout=output,
+        )
+
+        self.item3.refresh_from_db()
+        self.assertEqual(
+            self.item3.uri,
+            "https://newdomain.com:8080/plugins/controlled-list-manager/item/item-3",
+        )
+
+    def test_change_url_base_normalizes_url(self):
+        output = io.StringIO()
+        management.call_command(
+            "controlled_lists",
+            operation="change_url_base",
+            host="example.org",
+            stdout=output,
+        )
+
+        self.item1.refresh_from_db()
+        self.assertTrue(self.item1.uri.startswith("https://"))
+        self.assertIn("example.org", self.item1.uri)

--- a/tests/cli_tests.py
+++ b/tests/cli_tests.py
@@ -450,3 +450,15 @@ class ChangeUrlBaseTests(TestCase):
         self.item1.refresh_from_db()
         self.assertTrue(self.item1.uri.startswith("https://"))
         self.assertIn("example.org", self.item1.uri)
+
+        management.call_command(
+            "controlled_lists",
+            operation="change_url_base",
+            host="http://test.org:80",
+            stdout=output,
+        )
+
+        self.item1.refresh_from_db()
+        self.assertTrue(self.item1.uri.startswith("http://"))
+        self.assertIn("test.org", self.item1.uri)
+        self.assertNotIn(":80", self.item1.uri)


### PR DESCRIPTION
Utility to change the base URL for all list items.  Most useful for development and controlled lists where you might need to change the base url as you transfer between systems.

Does not change path.  Will change the scheme, if it's provided (see examples).

Example Usage:

python3 manage.py controlled_lists -o change_url_base -ho staging.casfdatabase.cpuc.ca.gov
python3 manage.py controlled_lists -o change_url_base -ho http://staging.casfdatabase.cpuc.ca.gov

