### PR TITLE
Allow for import from directories and export of multiple lists

### DIFF
--- a/arches_controlled_lists/management/commands/controlled_lists.py
+++ b/arches_controlled_lists/management/commands/controlled_lists.py
@@ -55,7 +55,8 @@ class Command(BaseCommand):
             action="store",
             dest="collections_to_migrate",
             nargs="*",
-            help="One or more collections to migrate to controlled lists",
+            help="One or more collections to migrate to controlled lists. "
+                 "To migrate all collections, provide an empty string ('') as the only argument.",
         )
 
         parser.add_argument(
@@ -105,14 +106,11 @@ class Command(BaseCommand):
                     )
                 )
 
-            if options["collections_to_migrate"] is None:
-                raise CommandError("No collections provided to migrate.")
-
             if not options["overwrite"]:
                 for collection_name in options["collections_to_migrate"]:
                     if List.objects.filter(name=collection_name).exists():
                         raise CommandError(
-                            f"The collection '{collection_name}' already exists."
+                            f"The controlled list '{collection_name}' already exists."
                         )
 
             self.migrate_collections_to_controlled_lists(
@@ -145,7 +143,11 @@ class Command(BaseCommand):
         preferred_sort_language,
     ):
         """
-        Uses a postgres function to migrate collections to controlled lists
+        Wrapper around __arches_migrate_collections_to_clm Postgres function to migrate 
+        concept collections to controlled lists for use in the controlled list manager plugin. 
+        Takes in a list of collection names to migrate, a host URL for URI generation,
+        a language code to use for develop sort order of list items based on prefLabel in that language,
+        and an overwrite boolean to determine whether to overwrite existing controlled lists or not.
 
         Example usage:
             python manage.py controlled_lists
@@ -173,6 +175,16 @@ class Command(BaseCommand):
                     valuetype__in=["prefLabel", "identifier"],
                     concept__nodetype="Collection",
                 ).values_list("value", flat=True)
+            )
+
+            if len(collections_in_db) == 0:
+                self.stderr.write(
+                    "No collections were found in the database to migrate to controlled lists."
+                )
+
+        if len(collections_in_db) == 0:
+            self.stderr.write(
+                "No collections were found in the database for the provided collection names."
             )
 
         failed_collections = [
@@ -405,35 +417,3 @@ class Command(BaseCommand):
             print(f"An error occurred while processing the URL: {e}")
             return url_string
 
-
-    def migrate__all_collections(self):
-        collections = (
-            Value.objects.filter(valuetype="prefLabel", concept__nodetype="Collection")
-            .order_by("value")
-            .values_list("value", flat=True)
-        )
-        for collection in collections:
-            management.call_command(
-                "controlled_lists",
-                "-o",
-                "migrate_collections_to_controlled_lists",
-                "-co",
-                collection,
-            )
-
-    def export_all_collections(self):
-        lists = List.objects.all()
-        for list in lists:
-            management.call_command(
-                "packages",
-                "-o",
-                "export_controlled_lists",
-                "-d",
-                "../arches-her/arches_her/pkg/reference_data/controlled_lists",
-                "-f",
-                "skos-rdf",
-                "-cl",
-                list.pk,
-                "-fn",
-                list.name,
-            )

--- a/arches_controlled_lists/management/commands/controlled_lists.py
+++ b/arches_controlled_lists/management/commands/controlled_lists.py
@@ -56,7 +56,7 @@ class Command(BaseCommand):
             dest="collections_to_migrate",
             nargs="*",
             help="One or more collections to migrate to controlled lists. "
-                 "To migrate all collections, provide an empty string ('') as the only argument.",
+            "To migrate all collections, provide an empty string ('') as the only argument.",
         )
 
         parser.add_argument(
@@ -143,8 +143,8 @@ class Command(BaseCommand):
         preferred_sort_language,
     ):
         """
-        Wrapper around __arches_migrate_collections_to_clm Postgres function to migrate 
-        concept collections to controlled lists for use in the controlled list manager plugin. 
+        Wrapper around __arches_migrate_collections_to_clm Postgres function to migrate
+        concept collections to controlled lists for use in the controlled list manager plugin.
         Takes in a list of collection names to migrate, a host URL for URI generation,
         a language code to use for develop sort order of list items based on prefLabel in that language,
         and an overwrite boolean to determine whether to overwrite existing controlled lists or not.
@@ -416,4 +416,3 @@ class Command(BaseCommand):
         except Exception as e:
             print(f"An error occurred while processing the URL: {e}")
             return url_string
-

--- a/arches_controlled_lists/management/commands/controlled_lists.py
+++ b/arches_controlled_lists/management/commands/controlled_lists.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlparse, urlunparse, urlsplit, urlunsplit
 from django.core.management.base import BaseCommand, CommandError
+from django.core import management
 from django.db import connection, models, transaction
 from django.db.models.expressions import CombinedExpression
 from django.db.models.fields.json import KT
@@ -403,3 +404,36 @@ class Command(BaseCommand):
         except Exception as e:
             print(f"An error occurred while processing the URL: {e}")
             return url_string
+
+
+    def migrate__all_collections(self):
+        collections = (
+            Value.objects.filter(valuetype="prefLabel", concept__nodetype="Collection")
+            .order_by("value")
+            .values_list("value", flat=True)
+        )
+        for collection in collections:
+            management.call_command(
+                "controlled_lists",
+                "-o",
+                "migrate_collections_to_controlled_lists",
+                "-co",
+                collection,
+            )
+
+    def export_all_collections(self):
+        lists = List.objects.all()
+        for list in lists:
+            management.call_command(
+                "packages",
+                "-o",
+                "export_controlled_lists",
+                "-d",
+                "../arches-her/arches_her/pkg/reference_data/controlled_lists",
+                "-f",
+                "skos-rdf",
+                "-cl",
+                list.pk,
+                "-fn",
+                list.name,
+            )

--- a/arches_controlled_lists/management/commands/packages.py
+++ b/arches_controlled_lists/management/commands/packages.py
@@ -2,6 +2,7 @@ import os
 import sys
 import glob
 import pyprind
+import uuid
 
 import openpyxl
 from django.db import transaction
@@ -50,8 +51,18 @@ class Command(PackagesCommand):
 
         if options["operation"] == "export_controlled_lists":
             file_name = options.get("file_name", None)
-            single_file = options.get("single_file", True)
-            if options["file_name"] and not options["single_file"]:
+            single_file = options.get("single_file", False)
+            parsed_lists = (
+                [lst.strip() for lst in options["controlled_lists"].split(",")]
+                if options["controlled_lists"]
+                else []
+            )
+
+            if (
+                options["file_name"]
+                and not options["single_file"]
+                and len(parsed_lists) > 1
+            ):
                 raise CommandError(
                     "The file_name argument cannot be used when the single_file flag is set to false. \
                     Please provide a file_name only when batch exporting controlled lists or a single list."
@@ -60,7 +71,7 @@ class Command(PackagesCommand):
             self.export_controlled_lists(
                 options["dest_dir"],
                 file_name,
-                options["controlled_lists"],
+                parsed_lists,
                 options["format"],
                 single_file,
             )
@@ -252,7 +263,7 @@ class Command(PackagesCommand):
         return instance_pks
 
     def export_controlled_lists(
-        self, data_dest, file_name, controlled_lists, format, single_file=False
+        self, data_dest, file_name, controlled_lists, format, single_file
     ):
 
         if format == "xlsx":
@@ -272,17 +283,23 @@ class Command(PackagesCommand):
                 )
 
         elif format == "skos-rdf":
-            hierarchies_for_export = []
-            parsed_lists = [lst.strip() for lst in controlled_lists.split(",")]
-
             if single_file:
-                if parsed_lists != [""]:
-                    export_lists = List.objects.filter(
-                        Q(name__in=parsed_lists) | Q(id__in=parsed_lists)
-                    )
-                    export_list_items = ListItem.objects.filter(
-                        list__in=export_lists
-                    ).prefetch_related("list_item_values", "parent", "children")
+                if controlled_lists != [""]:
+                    export_lists = []
+                    export_list_items = []
+                    for lst in controlled_lists:
+                        try:
+                            uuid_lst = uuid.UUID(lst)
+                            export_lists.append(
+                                List.objects.filter(id=uuid_lst).first()
+                            )
+                        except ValueError:
+                            export_lists.append(List.objects.filter(name=lst).first())
+                        export_list_items.append(
+                            ListItem.objects.filter(
+                                list__in=export_lists
+                            ).prefetch_related("list_item_values", "parent", "children")
+                        )
                 else:
                     export_lists = List.objects.all()
                     export_list_items = ListItem.objects.all().prefetch_related(
@@ -297,9 +314,13 @@ class Command(PackagesCommand):
                 )
 
             elif not single_file:
-                if parsed_lists != [""]:
-                    for lst in parsed_lists:
-                        export_lists = List.objects.filter(Q(name=lst) | Q(id=lst))
+                if controlled_lists != [""]:
+                    for lst in controlled_lists:
+                        try:
+                            uuid_lst = uuid.UUID(lst)
+                            export_lists = List.objects.filter(id=uuid_lst)
+                        except ValueError:
+                            export_lists = List.objects.filter(name=lst)
                         export_list_items = ListItem.objects.filter(
                             list__in=export_lists
                         ).prefetch_related("list_item_values", "parent", "children")

--- a/arches_controlled_lists/management/commands/packages.py
+++ b/arches_controlled_lists/management/commands/packages.py
@@ -6,6 +6,7 @@ import pyprind
 import openpyxl
 from django.db import transaction
 from django.db.models import Q
+from django.core.management.base import CommandError
 
 from arches.management.commands.packages import Command as PackagesCommand
 from arches.app.models import models

--- a/arches_controlled_lists/management/commands/packages.py
+++ b/arches_controlled_lists/management/commands/packages.py
@@ -37,8 +37,8 @@ class Command(PackagesCommand):
             type=str,
             dest="controlled_lists",
             help="A comma-separated list of controlled list names to export. "
-                 "If not provided, all controlled lists will be exported. "
-                 "For SKOS/RDF-XML, use the -single_file flag to export all controlled lists to a single file.",
+            "If not provided, all controlled lists will be exported. "
+            "For SKOS/RDF-XML, use the -single_file flag to export all controlled lists to a single file.",
         )
 
     def handle(self, *args, **options):
@@ -51,8 +51,10 @@ class Command(PackagesCommand):
             file_name = options.get("file_name", None)
             single_file = options.get("single_file", True)
             if options["file_name"] and not options["single_file"]:
-                raise CommandError("The file_name argument cannot be used when the single_file flag is set to false. \
-                    Please provide a file_name only when batch exporting controlled lists or a single list.")
+                raise CommandError(
+                    "The file_name argument cannot be used when the single_file flag is set to false. \
+                    Please provide a file_name only when batch exporting controlled lists or a single list."
+                )
 
             self.export_controlled_lists(
                 options["dest_dir"],
@@ -238,7 +240,9 @@ class Command(PackagesCommand):
 
         return instance_pks
 
-    def export_controlled_lists(self, data_dest, file_name, controlled_lists, format, single_file=False):
+    def export_controlled_lists(
+        self, data_dest, file_name, controlled_lists, format, single_file=False
+    ):
 
         if format == "xlsx":
             wb = openpyxl.Workbook()
@@ -260,7 +264,6 @@ class Command(PackagesCommand):
             hierarchies_for_export = []
             parsed_lists = [lst.strip() for lst in controlled_lists.split(",")]
 
-
             if single_file:
                 if parsed_lists != [""]:
                     export_lists = List.objects.filter(
@@ -279,15 +282,13 @@ class Command(PackagesCommand):
                     export_lists,
                     export_list_items,
                     data_dest,
-                    file_name or export_lists.first().name
+                    file_name or self._slugify(export_lists.first().name),
                 )
 
             elif not single_file:
                 if parsed_lists != [""]:
                     for lst in parsed_lists:
-                        export_lists = List.objects.filter(
-                            Q(name=lst) | Q(id=lst)
-                        )
+                        export_lists = List.objects.filter(Q(name=lst) | Q(id=lst))
                         export_list_items = ListItem.objects.filter(
                             list__in=export_lists
                         ).prefetch_related("list_item_values", "parent", "children")
@@ -296,7 +297,7 @@ class Command(PackagesCommand):
                             export_lists,
                             export_list_items,
                             data_dest,
-                            export_lists.first().name
+                            self._slugify(export_lists.first().name),
                         )
                 else:
                     export_lists = List.objects.all()
@@ -306,18 +307,17 @@ class Command(PackagesCommand):
                         ).prefetch_related("list_item_values", "parent", "children")
 
                         self._write_to_skos_file(
-                            [lst],
-                            export_list_items,
-                            data_dest,
-                            lst.name
+                            [lst], export_list_items, data_dest, self._slugify(lst.name)
                         )
 
         else:
             self.stdout.write(
                 f"The specified format {format} is not supported. Please rerun this command with a supported format."
             )
-    
-    def _write_to_skos_file(self, export_lists, export_list_items, data_dest, file_name):
+
+    def _write_to_skos_file(
+        self, export_lists, export_list_items, data_dest, file_name
+    ):
         skos = SKOSWriter()
         skos_file = skos.write_controlled_lists(
             export_lists, export_list_items, format="pretty-xml"
@@ -327,6 +327,9 @@ class Command(PackagesCommand):
             with open(os.path.join(data_dest, f"{file_name}.xml"), "wb") as file:
                 file.write(skos_file)
             self.stdout.write(f"Data exported successfully to {file_name}.xml")
+
+    def _slugify(self, value):
+        return value.lower().replace(" ", "_").replace("/", "_")
 
     def export_model_to_sheet(self, wb, model):
         # For the first sheet (List), use blank sheet that is initiallized with workbook

--- a/arches_controlled_lists/management/commands/packages.py
+++ b/arches_controlled_lists/management/commands/packages.py
@@ -118,17 +118,13 @@ class Command(PackagesCommand):
             )
             sys.exit()
 
-    def _import_controlled_lists_from_dir(self, package_dir, overwrite_options):
+    def _import_controlled_lists_from_dir(self, dir, overwrite_options):
         file_types = ["*.xml", "*.xlsx"]
+        reference_data_dir = os.path.join(dir, "reference_data", "controlled_lists")
+        search_dir = reference_data_dir if os.path.isdir(reference_data_dir) else dir
         controlled_list_files = []
         for file_type in file_types:
-            controlled_list_files.extend(
-                glob.glob(
-                    os.path.join(
-                        package_dir, "reference_data", "controlled_lists", file_type
-                    )
-                )
-            )
+            controlled_list_files.extend(glob.glob(os.path.join(search_dir, file_type)))
 
         bar = (
             pyprind.ProgBar(

--- a/arches_controlled_lists/management/commands/packages.py
+++ b/arches_controlled_lists/management/commands/packages.py
@@ -91,37 +91,36 @@ class Command(PackagesCommand):
 
     def load_concepts(self, package_dir, overwrite, stage, defer_indexing):
         super().load_concepts(package_dir, overwrite, stage, defer_indexing)
+        print("Importing controlled lists...")
+        self.load_controlled_lists(package_dir, overwrite or "overwrite")
 
-        def load_controlled_lists(package_dir, overwrite_options):
-            file_types = ["*.xml", "*.xlsx"]
-            controlled_list_files = []
-            for file_type in file_types:
-                controlled_list_files.extend(
-                    glob.glob(
-                        os.path.join(
-                            package_dir, "reference_data", "controlled_lists", file_type
-                        )
+    def load_controlled_lists(self, package_dir, overwrite_options):
+        file_types = ["*.xml", "*.xlsx"]
+        controlled_list_files = []
+        for file_type in file_types:
+            controlled_list_files.extend(
+                glob.glob(
+                    os.path.join(
+                        package_dir, "reference_data", "controlled_lists", file_type
                     )
                 )
-
-            bar = (
-                pyprind.ProgBar(
-                    len(controlled_list_files), bar_char="█", stream=self.stdout
-                )
-                if len(controlled_list_files) > 1
-                else None
             )
 
-            for path in controlled_list_files:
-                if bar is None:
-                    print(path)
-                self.import_controlled_lists(path, overwrite_options)
-                if bar is not None:
-                    head, tail = os.path.split(path)
-                    bar.update(item_id=tail + (" " * 10))
+        bar = (
+            pyprind.ProgBar(
+                len(controlled_list_files), bar_char="█", stream=self.stdout
+            )
+            if len(controlled_list_files) > 1
+            else None
+        )
 
-        print("Importing controlled lists...")
-        load_controlled_lists(package_dir, overwrite or "overwrite")
+        for path in controlled_list_files:
+            if bar is None:
+                self.stdout.write(path)
+            self.import_controlled_lists(path, overwrite_options)
+            if bar is not None:
+                head, tail = os.path.split(path)
+                bar.update(item_id=tail + (" " * 10))
 
     def import_controlled_lists(self, source, overwrite_options):
 

--- a/arches_controlled_lists/management/commands/packages.py
+++ b/arches_controlled_lists/management/commands/packages.py
@@ -262,10 +262,30 @@ class Command(PackagesCommand):
 
         return instance_pks
 
+    def _validate_controlled_lists(self, controlled_lists):
+        not_found = []
+        resolved_lists = []
+        for list_identifier in controlled_lists:
+            try:
+                list_uuid = uuid.UUID(list_identifier)
+                resolved_list = List.objects.filter(id=list_uuid).first()
+            except ValueError:
+                resolved_list = List.objects.filter(name=list_identifier).first()
+            if resolved_list is None:
+                not_found.append(list_identifier)
+            else:
+                resolved_lists.append(resolved_list)
+
+        if not_found:
+            raise CommandError(
+                "The following controlled lists were not found: " + ", ".join(not_found)
+            )
+
+        return resolved_lists
+
     def export_controlled_lists(
         self, data_dest, file_name, controlled_lists, format, single_file
     ):
-
         if format == "xlsx":
             wb = openpyxl.Workbook()
             ws = wb.active
@@ -283,64 +303,35 @@ class Command(PackagesCommand):
                 )
 
         elif format == "skos-rdf":
+            if controlled_lists and controlled_lists != [""]:
+                export_lists = self._validate_controlled_lists(controlled_lists)
+            else:
+                export_lists = list(List.objects.all())
+
             if single_file:
-                if controlled_lists != [""]:
-                    export_lists = []
-                    export_list_items = []
-                    for lst in controlled_lists:
-                        try:
-                            uuid_lst = uuid.UUID(lst)
-                            export_lists.append(
-                                List.objects.filter(id=uuid_lst).first()
-                            )
-                        except ValueError:
-                            export_lists.append(List.objects.filter(name=lst).first())
-                        export_list_items.append(
-                            ListItem.objects.filter(
-                                list__in=export_lists
-                            ).prefetch_related("list_item_values", "parent", "children")
-                        )
-                else:
-                    export_lists = List.objects.all()
-                    export_list_items = ListItem.objects.all().prefetch_related(
-                        "list_item_values", "parent", "children"
-                    )
+                export_list_items = ListItem.objects.filter(
+                    list__in=export_lists
+                ).prefetch_related("list_item_values", "parent", "children")
 
                 self._write_to_skos_file(
                     export_lists,
                     export_list_items,
                     data_dest,
-                    file_name or self._slugify(export_lists.first().name),
+                    file_name or self._slugify(export_lists[0].name),
                 )
 
             elif not single_file:
-                if controlled_lists != [""]:
-                    for lst in controlled_lists:
-                        try:
-                            uuid_lst = uuid.UUID(lst)
-                            export_lists = List.objects.filter(id=uuid_lst)
-                        except ValueError:
-                            export_lists = List.objects.filter(name=lst)
-                        export_list_items = ListItem.objects.filter(
-                            list__in=export_lists
-                        ).prefetch_related("list_item_values", "parent", "children")
+                for controlled_list in export_lists:
+                    export_list_items = ListItem.objects.filter(
+                        list=controlled_list
+                    ).prefetch_related("list_item_values", "parent", "children")
 
-                        self._write_to_skos_file(
-                            export_lists,
-                            export_list_items,
-                            data_dest,
-                            self._slugify(export_lists.first().name),
-                        )
-                else:
-                    export_lists = List.objects.all()
-                    for lst in export_lists:
-                        export_list_items = ListItem.objects.filter(
-                            list=lst
-                        ).prefetch_related("list_item_values", "parent", "children")
-
-                        self._write_to_skos_file(
-                            [lst], export_list_items, data_dest, self._slugify(lst.name)
-                        )
+                    self._write_to_skos_file(
+                        [controlled_list],
+                        export_list_items,
+                        data_dest,
+                        self._slugify(controlled_list.name),
+                    )
 
         else:
             self.stdout.write(

--- a/arches_controlled_lists/management/commands/packages.py
+++ b/arches_controlled_lists/management/commands/packages.py
@@ -28,8 +28,7 @@ class Command(PackagesCommand):
             "--file_name",
             type=str,
             dest="file_name",
-            default="export_controlled_lists",
-            help="The name of the file to export to. Default is export_controlled_lists",
+            help="The name of the file to export to. Default is the first (or only) controlled list that is being exported",
         )
 
         parser.add_argument(
@@ -37,7 +36,9 @@ class Command(PackagesCommand):
             "--controlled_lists",
             type=str,
             dest="controlled_lists",
-            help="A comma-separated list of controlled list names to export. If not provided, all controlled lists will be exported.",
+            help="A comma-separated list of controlled list names to export. "
+                 "If not provided, all controlled lists will be exported. "
+                 "For SKOS/RDF-XML, use the -single_file flag to export all controlled lists to a single file.",
         )
 
     def handle(self, *args, **options):
@@ -47,11 +48,18 @@ class Command(PackagesCommand):
             self.import_controlled_lists(options["source"], options["overwrite"])
 
         if options["operation"] == "export_controlled_lists":
+            file_name = options.get("file_name", None)
+            single_file = options.get("single_file", True)
+            if options["file_name"] and not options["single_file"]:
+                raise CommandError("The file_name argument cannot be used when the single_file flag is set to false. \
+                    Please provide a file_name only when batch exporting controlled lists or a single list.")
+
             self.export_controlled_lists(
                 options["dest_dir"],
-                options["file_name"],
+                file_name,
                 options["controlled_lists"],
                 options["format"],
+                single_file,
             )
 
     def load_package(
@@ -230,7 +238,7 @@ class Command(PackagesCommand):
 
         return instance_pks
 
-    def export_controlled_lists(self, data_dest, file_name, controlled_lists, format):
+    def export_controlled_lists(self, data_dest, file_name, controlled_lists, format, single_file=False):
 
         if format == "xlsx":
             wb = openpyxl.Workbook()
@@ -249,33 +257,76 @@ class Command(PackagesCommand):
                 )
 
         elif format == "skos-rdf":
+            hierarchies_for_export = []
             parsed_lists = [lst.strip() for lst in controlled_lists.split(",")]
-            if parsed_lists != [""]:
-                export_lists = List.objects.filter(
-                    Q(name__in=parsed_lists) | Q(id__in=parsed_lists)
-                )
-                export_list_items = ListItem.objects.filter(
-                    list__in=export_lists
-                ).prefetch_related("list_item_values", "parent", "children")
-            else:
-                export_lists = List.objects.all()
-                export_list_items = ListItem.objects.all().prefetch_related(
-                    "list_item_values", "parent", "children"
-                )
-            skos = SKOSWriter()
-            skos_file = skos.write_controlled_lists(
-                export_lists, export_list_items, format="pretty-xml"
-            )
 
-            if data_dest != "" and data_dest != ".":
-                with open(os.path.join(data_dest, f"{file_name}.xml"), "wb") as file:
-                    file.write(skos_file)
-                self.stdout.write(f"Data exported successfully to {file_name}.xml")
+
+            if single_file:
+                if parsed_lists != [""]:
+                    export_lists = List.objects.filter(
+                        Q(name__in=parsed_lists) | Q(id__in=parsed_lists)
+                    )
+                    export_list_items = ListItem.objects.filter(
+                        list__in=export_lists
+                    ).prefetch_related("list_item_values", "parent", "children")
+                else:
+                    export_lists = List.objects.all()
+                    export_list_items = ListItem.objects.all().prefetch_related(
+                        "list_item_values", "parent", "children"
+                    )
+
+                self._write_to_skos_file(
+                    export_lists,
+                    export_list_items,
+                    data_dest,
+                    file_name or export_lists.first().name
+                )
+
+            elif not single_file:
+                if parsed_lists != [""]:
+                    for lst in parsed_lists:
+                        export_lists = List.objects.filter(
+                            Q(name=lst) | Q(id=lst)
+                        )
+                        export_list_items = ListItem.objects.filter(
+                            list__in=export_lists
+                        ).prefetch_related("list_item_values", "parent", "children")
+
+                        self._write_to_skos_file(
+                            export_lists,
+                            export_list_items,
+                            data_dest,
+                            export_lists.first().name
+                        )
+                else:
+                    export_lists = List.objects.all()
+                    for lst in export_lists:
+                        export_list_items = ListItem.objects.filter(
+                            list=lst
+                        ).prefetch_related("list_item_values", "parent", "children")
+
+                        self._write_to_skos_file(
+                            [lst],
+                            export_list_items,
+                            data_dest,
+                            lst.name
+                        )
 
         else:
             self.stdout.write(
                 f"The specified format {format} is not supported. Please rerun this command with a supported format."
             )
+    
+    def _write_to_skos_file(self, export_lists, export_list_items, data_dest, file_name):
+        skos = SKOSWriter()
+        skos_file = skos.write_controlled_lists(
+            export_lists, export_list_items, format="pretty-xml"
+        )
+
+        if data_dest != "" and data_dest != ".":
+            with open(os.path.join(data_dest, f"{file_name}.xml"), "wb") as file:
+                file.write(skos_file)
+            self.stdout.write(f"Data exported successfully to {file_name}.xml")
 
     def export_model_to_sheet(self, wb, model):
         # For the first sheet (List), use blank sheet that is initiallized with workbook

--- a/arches_controlled_lists/management/commands/packages.py
+++ b/arches_controlled_lists/management/commands/packages.py
@@ -92,9 +92,21 @@ class Command(PackagesCommand):
     def load_concepts(self, package_dir, overwrite, stage, defer_indexing):
         super().load_concepts(package_dir, overwrite, stage, defer_indexing)
         print("Importing controlled lists...")
-        self.load_controlled_lists(package_dir, overwrite or "overwrite")
+        self._import_controlled_lists_from_dir(package_dir, overwrite or "overwrite")
 
-    def load_controlled_lists(self, package_dir, overwrite_options):
+    def import_controlled_lists(self, source, overwrite_options):
+        if os.path.isdir(source):
+            self._import_controlled_lists_from_dir(source, overwrite_options)
+        elif os.path.isfile(source):
+            self._import_controlled_list_from_file(source, overwrite_options)
+            print('Successfully imported "{0}"'.format(source))
+        else:
+            self.stdout.write(
+                "The source file or directory does not exist. Please rerun this command with a valid source file or directory."
+            )
+            sys.exit()
+
+    def _import_controlled_lists_from_dir(self, package_dir, overwrite_options):
         file_types = ["*.xml", "*.xlsx"]
         controlled_list_files = []
         for file_type in file_types:
@@ -117,13 +129,12 @@ class Command(PackagesCommand):
         for path in controlled_list_files:
             if bar is None:
                 self.stdout.write(path)
-            self.import_controlled_lists(path, overwrite_options)
+            self._import_controlled_list_from_file(path, overwrite_options)
             if bar is not None:
                 head, tail = os.path.split(path)
                 bar.update(item_id=tail + (" " * 10))
 
-    def import_controlled_lists(self, source, overwrite_options):
-
+    def _import_controlled_list_from_file(self, source, overwrite_options):
         if source.lower().endswith(".xml"):
             skos = SKOSReader()
             rdf = skos.read_file(source)

--- a/arches_controlled_lists/utils/skos.py
+++ b/arches_controlled_lists/utils/skos.py
@@ -240,7 +240,7 @@ class SKOSReader(SKOSReader):
             return uuid.uuid5(baseuuid, str(subject))
 
 
-class SKOSWriter(SKOSReader):
+class SKOSWriter(SKOSWriter):
     def write_controlled_lists(self, lists, list_items, format):
         # get empty RDF graph
         rdf_graph = Graph()

--- a/tests/cli_tests.py
+++ b/tests/cli_tests.py
@@ -125,6 +125,38 @@ class ListExportPackageTests(TestCase):
             )
         self.assertTrue(os.path.exists(file_path))
 
+    def test_export_multi_lists_single_file_raises(self):
+        output = io.StringIO()
+        with captured_stdout():
+            with self.assertRaises(CommandError):
+                management.call_command(
+                    "packages",
+                    operation="export_controlled_lists",
+                    dest_dir=PROJECT_TEST_ROOT,
+                    file_name="invalid_export",
+                    controlled_lists="list1,list2",
+                    format="skos-rdf",
+                    stdout=output,
+                )
+
+    def test_export_multi_lists_multi_file(self):
+        output = io.StringIO()
+        with captured_stdout():
+            management.call_command(
+                "packages",
+                operation="export_controlled_lists",
+                dest_dir=PROJECT_TEST_ROOT,
+                controlled_lists="list1,list2",
+                format="skos-rdf",
+                stdout=output,
+            )
+        file_path_list1 = os.path.join(PROJECT_TEST_ROOT, f"list1.xml")
+        file_path_list2 = os.path.join(PROJECT_TEST_ROOT, f"list2.xml")
+        self.assertTrue(os.path.exists(file_path_list1))
+        self.assertTrue(os.path.exists(file_path_list2))
+        self.addCleanup(os.remove, file_path_list1)
+        self.addCleanup(os.remove, file_path_list2)
+
 
 class ListImportPackageTests(TestCase):
 

--- a/tests/cli_tests.py
+++ b/tests/cli_tests.py
@@ -218,6 +218,25 @@ class ListImportPackageTests(TestCase):
         self.assertEqual(ListItem.objects.count(), 34)
         self.assertEqual(ListItemValue.objects.count(), 42)
 
+    def test_import_from_skos_via_directory(self):
+        input_dir = os.path.join(
+            TEST_PACKAGE_DIR,
+        )
+        output = io.StringIO()
+        # packages command does not yet fully avoid print()
+        with captured_stdout():
+            management.call_command(
+                "packages",
+                operation="import_controlled_lists",
+                source=input_dir,
+                overwrite="ignore",
+                stdout=output,
+            )
+
+        self.assertEqual(List.objects.count(), 1)
+        self.assertEqual(ListItem.objects.count(), 17)
+        self.assertEqual(ListItemValue.objects.count(), 21)
+
 
 class RDMToControlledListsETLTests(TestCase):
     fixtures = ["polyhierarchical_collections"]

--- a/tests/cli_tests.py
+++ b/tests/cli_tests.py
@@ -69,7 +69,7 @@ class ListExportPackageTests(TestCase):
             )
         self.assertTrue(os.path.exists(file_path))
 
-    def test_export_controlled_list_skos(self):
+    def test_export_controlled_single_list_skos(self):
         export_file_name = "lists_skos_export"
         file_path = os.path.join(PROJECT_TEST_ROOT, f"{export_file_name}.xml")
         self.addCleanup(os.remove, file_path)
@@ -81,7 +81,45 @@ class ListExportPackageTests(TestCase):
                 operation="export_controlled_lists",
                 dest_dir=PROJECT_TEST_ROOT,
                 file_name=export_file_name,
+                controlled_lists="list1",
+                single_file=True,
+                format="skos-rdf",
+                stdout=output,
+            )
+        self.assertTrue(os.path.exists(file_path))
+
+    def test_export_controlled_all_lists_skos(self):
+        export_file_name = "all_lists_skos_export"
+        file_path = os.path.join(PROJECT_TEST_ROOT, f"{export_file_name}.xml")
+        self.addCleanup(os.remove, file_path)
+        output = io.StringIO()
+        # packages command does not yet fully avoid print()
+        with captured_stdout():
+            management.call_command(
+                "packages",
+                operation="export_controlled_lists",
+                dest_dir=PROJECT_TEST_ROOT,
+                file_name=export_file_name,
                 controlled_lists="",
+                single_file=True,
+                format="skos-rdf",
+                stdout=output,
+            )
+        self.assertTrue(os.path.exists(file_path))
+
+    def test_export_controlled_file_name_default_skos(self):
+        file_path = os.path.join(PROJECT_TEST_ROOT, f"{'list1'}.xml")
+        self.addCleanup(os.remove, file_path)
+        output = io.StringIO()
+        # packages command does not yet fully avoid print()
+        with captured_stdout():
+            management.call_command(
+                "packages",
+                operation="export_controlled_lists",
+                dest_dir=PROJECT_TEST_ROOT,
+                file_name="list1",
+                controlled_lists="",
+                single_file=True,
                 format="skos-rdf",
                 stdout=output,
             )


### PR DESCRIPTION
I needed to move all of my collections to controlled lists and then export them all out as individual skos files. These added methods do that. I actually created them in a different file, so they would need to be wired up in the handle method here. This was really just a quick and dirty solution, but I think the functionality is really needed in 1.1.