### PR TITLE
#223 follow up

### DIFF
--- a/arches_controlled_lists/src/arches_controlled_lists/widgets/ReferenceSelectWidget/components/ReferenceSelectWidgetEditor.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/widgets/ReferenceSelectWidget/components/ReferenceSelectWidgetEditor.vue
@@ -56,6 +56,13 @@ const initialValueFromTileData = computed(() => {
     const defaultValueFromWidgetConfig = cardXNodeXWidgetData?.config
         ?.defaultValue as ReferenceSelectNodeValue[] | undefined;
 
+    if (
+        !defaultValueFromWidgetConfig ||
+        defaultValueFromWidgetConfig.length === 0
+    ) {
+        return undefined;
+    }
+
     return defaultValueFromWidgetConfig?.reduce<Record<string, boolean>>(
         (accumulator, defaultValueItem) => {
             const listItemIdentifier =

--- a/releases/1.1.0.md
+++ b/releases/1.1.0.md
@@ -24,13 +24,13 @@ JavaScript:
 ```
 
 ### Major enhancements
- - 
 
-- Adds a utility to modify the base url for controlled list items.
+- Adds a utility to modify the base url for controlled list items. [#210](https://github.com/archesproject/arches-controlled-lists/pull/210)
+- 
 
 ### Additional highlights
 
--
+- Fixed a bug where defaults values were not populated in the vue widget [#243](https://github.com/archesproject/arches-controlled-lists/issues/223)
 
 ### Upgrading Arches Controlled Lists
 


### PR DESCRIPTION
Hey @chrabyrd, I was a bit too quick on merging #224. Here's a follow up for two things:
- release note
- guard against issues with empty string default values

The default config for Reference cardxnodexwidgets includes `defaultValue: ""`... this really should be `defaultValue: null`. I'm filing this as a follow up because priorities and it will likely require a migration + updating the Concept -> Reference node migration script. 