### PR TITLE
Make reference-select filterable

### DIFF
--- a/arches_controlled_lists/media/js/viewmodels/reference-select.js
+++ b/arches_controlled_lists/media/js/viewmodels/reference-select.js
@@ -1,16 +1,16 @@
-import $ from "jquery";
-import ko from "knockout";
-import koMapping from "knockout-mapping";
-import arches from "arches";
-import WidgetViewModel from "viewmodels/widget";
+import $ from 'jquery';
+import ko from 'knockout';
+import koMapping from 'knockout-mapping';
+import arches from 'arches';
+import WidgetViewModel from 'viewmodels/widget';
 
 export default function (params) {
     const NAME_LOOKUP = {};
     var self = this;
 
-    params.configKeys = ["placeholder", "defaultValue"];
+    params.configKeys = ['placeholder', 'defaultValue'];
     this.multiple = !!ko.unwrap(params.node.config.multiValue);
-    this.displayName = ko.observable("");
+    this.displayName = ko.observable('');
     this.selectionValue = ko.observable([]); // formatted version of this.value that select2 can use
     this.activeLanguage = arches.activeLanguage;
 
@@ -23,20 +23,20 @@ export default function (params) {
                 ?.find(
                     (label) =>
                         label.language_id === arches.activeLanguage &&
-                        label.valuetype_id === "prefLabel",
+                        label.valuetype_id === 'prefLabel',
                 )?.value || arches.translations.unlabeledItem
         );
     };
 
     this.isLabel = function (value) {
-        return ["prefLabel", "altLabel"].includes(value.valuetype_id);
+        return ['prefLabel', 'altLabel'].includes(value.valuetype_id);
     };
 
     this.displayValue = ko.computed(function () {
         const val = self.value();
         let name = null;
         if (val) {
-            name = val.map((item) => self.getPrefLabel(item.labels)).join(", ");
+            name = val.map((item) => self.getPrefLabel(item.labels)).join(', ');
         }
         return name;
     });
@@ -61,8 +61,8 @@ export default function (params) {
                 const newItem = selection.map((id) => {
                     return {
                         labels: NAME_LOOKUP[id].labels,
-                        list_id: NAME_LOOKUP[id]["list_id"],
-                        uri: NAME_LOOKUP[id]["uri"],
+                        list_id: NAME_LOOKUP[id]['list_id'],
+                        uri: NAME_LOOKUP[id]['uri'],
                     };
                 });
                 self.value(newItem);
@@ -97,19 +97,19 @@ export default function (params) {
             url: arches.urls.controlled_list_filtered(
                 ko.unwrap(params.node.config.controlledList),
             ),
-            dataType: "json",
+            dataType: 'json',
             quietMillis: 250,
             data: function (requestParams) {
                 return {
-                    term: requestParams.term || "",
+                    term: requestParams.term || '',
                     flat: true,
                 };
             },
             processResults: function (data, requestParams) {
                 const items = data.items;
-                const term = (requestParams?.term || "").toLowerCase();
+                const term = (requestParams?.term || '').toLowerCase();
                 items.forEach((item) => {
-                    item["list_id"] = item.list_id;
+                    item['list_id'] = item.list_id;
                     item.uri = item.uri;
                     item.disabled = item.guide;
                     item.labels = item.values.filter((val) =>
@@ -129,7 +129,7 @@ export default function (params) {
             if (item.uri) {
                 const text =
                     self.getPrefLabel(item.labels) ||
-                    arches.translations.searching + "...";
+                    arches.translations.searching + '...';
                 NAME_LOOKUP[item.labels[0].list_item_id] = {
                     prefLabel: text,
                     labels: item.labels,
@@ -141,22 +141,21 @@ export default function (params) {
                         text +
                         '<span style="display:block;font-size:0.85em;opacity:0.6;">(' +
                         item.parent_path +
-                        ")</span>"
+                        ')</span>'
                     );
                 }
-                let indentation = "";
+                let indentation = '';
                 for (let i = 0; i < item.depth; i++) {
-                    indentation += "&nbsp;&nbsp;&nbsp;&nbsp;";
+                    indentation += '&nbsp;&nbsp;&nbsp;&nbsp;';
                 }
                 return indentation + text;
             }
         },
         templateSelection: function (item) {
-            if (!item.uri) {
-                // option has a different shape when coming from initSelection vs templateResult
+            if (!item.uri) { // option has a different shape when coming from initSelection vs templateResult
                 return item.text;
             } else {
-                return NAME_LOOKUP[item.labels[0].list_item_id]["prefLabel"];
+                return NAME_LOOKUP[item.labels[0].list_item_id]['prefLabel'];
             }
         },
         escapeMarkup: function (markup) {

--- a/arches_controlled_lists/media/js/viewmodels/reference-select.js
+++ b/arches_controlled_lists/media/js/viewmodels/reference-select.js
@@ -1,60 +1,68 @@
-import $ from 'jquery';
-import ko from 'knockout';
-import koMapping from 'knockout-mapping';
-import arches from 'arches';
-import WidgetViewModel from 'viewmodels/widget';
+import $ from "jquery";
+import ko from "knockout";
+import koMapping from "knockout-mapping";
+import arches from "arches";
+import WidgetViewModel from "viewmodels/widget";
 
-export default function(params) {
+export default function (params) {
     const NAME_LOOKUP = {};
     var self = this;
 
-    params.configKeys = ['placeholder', 'defaultValue'];
+    params.configKeys = ["placeholder", "defaultValue"];
     this.multiple = !!ko.unwrap(params.node.config.multiValue);
-    this.displayName = ko.observable('');
+    this.displayName = ko.observable("");
     this.selectionValue = ko.observable([]); // formatted version of this.value that select2 can use
     this.activeLanguage = arches.activeLanguage;
 
     WidgetViewModel.apply(this, [params]);
 
-    this.getPrefLabel = function(labels){
-        return koMapping.toJS(labels)?.find(
-            label => label.language_id === arches.activeLanguage && label.valuetype_id === 'prefLabel'
-        )?.value || arches.translations.unlabeledItem;
-    }; 
-
-    this.isLabel = function (value) {
-        return ['prefLabel', 'altLabel'].includes(value.valuetype_id);
+    this.getPrefLabel = function (labels) {
+        return (
+            koMapping
+                .toJS(labels)
+                ?.find(
+                    (label) =>
+                        label.language_id === arches.activeLanguage &&
+                        label.valuetype_id === "prefLabel",
+                )?.value || arches.translations.unlabeledItem
+        );
     };
 
-    this.displayValue = ko.computed(function() {
+    this.isLabel = function (value) {
+        return ["prefLabel", "altLabel"].includes(value.valuetype_id);
+    };
+
+    this.displayValue = ko.computed(function () {
         const val = self.value();
         let name = null;
         if (val) {
-            name = val.map(item => self.getPrefLabel(item.labels)).join(", ");
+            name = val.map((item) => self.getPrefLabel(item.labels)).join(", ");
         }
         return name;
     });
 
-    this.valueAndSelectionDiffer = function(value, selection) {
+    this.valueAndSelectionDiffer = function (value, selection) {
         if (!(ko.unwrap(value) instanceof Array)) {
             return true;
         }
-        const valueIds = ko.unwrap(value).map(val=>{
+        const valueIds = ko.unwrap(value).map((val) => {
             const listItemLabels = ko.unwrap(val.labels);
             return ko.unwrap(listItemLabels[0]?.list_item_id);
         });
         return JSON.stringify(selection) !== JSON.stringify(valueIds);
     };
 
-    this.selectionValue.subscribe(selection => {
+    this.selectionValue.subscribe((selection) => {
         if (selection) {
-            if (!(selection instanceof Array)) { selection = [selection]; }
+            if (!(selection instanceof Array)) {
+                selection = [selection];
+            }
             if (self.valueAndSelectionDiffer(self.value, selection)) {
-                const newItem = selection.map(id => {
+                const newItem = selection.map((id) => {
                     return {
-                        "labels": NAME_LOOKUP[id].labels,
-                        "list_id": NAME_LOOKUP[id]["list_id"],
-                        "uri": NAME_LOOKUP[id]["uri"],
+                        labels: NAME_LOOKUP[id].labels,
+                        list_id: NAME_LOOKUP[id]["list_id"],
+                        uri: NAME_LOOKUP[id]["uri"],
                     };
                 });
                 self.value(newItem);
@@ -64,12 +72,14 @@ export default function(params) {
         }
     });
 
-    this.value.subscribe(val => {
+    this.value.subscribe((val) => {
         if (val?.length) {
-            self.selectionValue(val.map(item=>{
-                const listItemLabels = ko.unwrap(item.labels);
-                return ko.unwrap(listItemLabels[0]?.list_item_id);
-            }));
+            self.selectionValue(
+                val.map((item) => {
+                    const listItemLabels = ko.unwrap(item.labels);
+                    return ko.unwrap(listItemLabels[0]?.list_item_id);
+                }),
+            );
         } else {
             self.selectionValue(null);
         }
@@ -77,85 +87,102 @@ export default function(params) {
 
     this.select2Config = {
         value: self.selectionValue,
-        minimumResultsForSearch: -1,
+        minimumInputLength: 0,
         clickBubble: true,
         multiple: this.multiple,
         closeOnSelect: true,
         placeholder: self.placeholder,
         allowClear: true,
         ajax: {
-            url: arches.urls.controlled_list(ko.unwrap(params.node.config.controlledList)),
-            dataType: 'json',
+            url: arches.urls.controlled_list_filtered(
+                ko.unwrap(params.node.config.controlledList),
+            ),
+            dataType: "json",
             quietMillis: 250,
-            data: function(requestParams) {
-
+            data: function (requestParams) {
                 return {
-                    flat: true
+                    term: requestParams.term || "",
+                    flat: true,
                 };
             },
-            processResults: function(data) {
-                const items = data.items; 
-                items.forEach(item => {
+            processResults: function (data, requestParams) {
+                const items = data.items;
+                const term = (requestParams?.term || "").toLowerCase();
+                items.forEach((item) => {
                     item["list_id"] = item.list_id;
                     item.uri = item.uri;
                     item.disabled = item.guide;
-                    item.labels = item.values.filter(val => self.isLabel(val));
+                    item.labels = item.values.filter((val) =>
+                        self.isLabel(val),
+                    );
+                    if (term) {
+                        item._filtered = true;
+                    }
                 });
                 return {
-                    "results": items,
-                    "pagination": {
-                        "more": false
-                    }
+                    results: items,
+                    pagination: { more: false },
                 };
-            }
+            },
         },
-        templateResult: function(item) {
-            let indentation = '';
-            for (let i = 0; i < item.depth; i++) {
-                indentation += '&nbsp;&nbsp;&nbsp;&nbsp;';
-            }
-
+        templateResult: function (item) {
             if (item.uri) {
-                const text = self.getPrefLabel(item.labels) || arches.translations.searching + '...';
+                const text =
+                    self.getPrefLabel(item.labels) ||
+                    arches.translations.searching + "...";
                 NAME_LOOKUP[item.labels[0].list_item_id] = {
-                    "prefLabel": text,
-                    "labels": item.labels,
-                    "list_id": item.list_id,
-                    "uri": item.uri,
+                    prefLabel: text,
+                    labels: item.labels,
+                    list_id: item.list_id,
+                    uri: item.uri,
                 };
+                if (item._filtered && item.parent_path) {
+                    return (
+                        text +
+                        '<span style="display:block;font-size:0.85em;opacity:0.6;">(' +
+                        item.parent_path +
+                        ")</span>"
+                    );
+                }
+                let indentation = "";
+                for (let i = 0; i < item.depth; i++) {
+                    indentation += "&nbsp;&nbsp;&nbsp;&nbsp;";
+                }
                 return indentation + text;
             }
         },
-        templateSelection: function(item) {
-            if (!item.uri) { // option has a different shape when coming from initSelection vs templateResult
+        templateSelection: function (item) {
+            if (!item.uri) {
+                // option has a different shape when coming from initSelection vs templateResult
                 return item.text;
             } else {
                 return NAME_LOOKUP[item.labels[0].list_item_id]["prefLabel"];
             }
         },
-        escapeMarkup: function(markup) { return markup; },
+        escapeMarkup: function (markup) {
+            return markup;
+        },
         initComplete: false,
-        initSelection: function(el, callback) {
-
-            const setSelectionData = function(data) {
+        initSelection: function (el, callback) {
+            const setSelectionData = function (data) {
                 const valueData = koMapping.toJS(self.value());
 
-                valueData.forEach(function(value) {
+                valueData.forEach(function (value) {
                     NAME_LOOKUP[value.labels[0].list_item_id] = {
-                            "prefLabel": self.getPrefLabel(value.labels),
-                            "labels": value.labels,
-                            "list_id": value.list_id,
-                            "uri": value.uri,
-                        };
+                        prefLabel: self.getPrefLabel(value.labels),
+                        labels: value.labels,
+                        list_id: value.list_id,
+                        uri: value.uri,
+                    };
                 });
-    
-                if(!self.select2Config.initComplete){
-                    valueData.forEach(function(data) {
+
+                if (!self.select2Config.initComplete) {
+                    valueData.forEach(function (data) {
                         const option = new Option(
                             self.getPrefLabel(data.labels),
                             data.labels[0].list_item_id,
-                            true, 
-                            true
+                            true,
+                            true,
                         );
                         $(el).append(option);
                         self.selectionValue().push(data.labels[0].list_item_id);
@@ -170,10 +197,8 @@ export default function(params) {
             } else {
                 callback([]);
             }
-
-        }
+        },
     };
     this.select2ConfigMulti = { ...this.select2Config };
     this.select2ConfigMulti.multiple = true;
-
-};
+}

--- a/arches_controlled_lists/media/js/viewmodels/reference-select.js
+++ b/arches_controlled_lists/media/js/viewmodels/reference-select.js
@@ -1,16 +1,16 @@
-import $ from 'jquery';
-import ko from 'knockout';
-import koMapping from 'knockout-mapping';
-import arches from 'arches';
-import WidgetViewModel from 'viewmodels/widget';
+import $ from "jquery";
+import ko from "knockout";
+import koMapping from "knockout-mapping";
+import arches from "arches";
+import WidgetViewModel from "viewmodels/widget";
 
 export default function (params) {
     const NAME_LOOKUP = {};
     var self = this;
 
-    params.configKeys = ['placeholder', 'defaultValue'];
+    params.configKeys = ["placeholder", "defaultValue"];
     this.multiple = !!ko.unwrap(params.node.config.multiValue);
-    this.displayName = ko.observable('');
+    this.displayName = ko.observable("");
     this.selectionValue = ko.observable([]); // formatted version of this.value that select2 can use
     this.activeLanguage = arches.activeLanguage;
 
@@ -23,20 +23,20 @@ export default function (params) {
                 ?.find(
                     (label) =>
                         label.language_id === arches.activeLanguage &&
-                        label.valuetype_id === 'prefLabel',
+                        label.valuetype_id === "prefLabel",
                 )?.value || arches.translations.unlabeledItem
         );
     };
 
     this.isLabel = function (value) {
-        return ['prefLabel', 'altLabel'].includes(value.valuetype_id);
+        return ["prefLabel", "altLabel"].includes(value.valuetype_id);
     };
 
     this.displayValue = ko.computed(function () {
         const val = self.value();
         let name = null;
         if (val) {
-            name = val.map((item) => self.getPrefLabel(item.labels)).join(', ');
+            name = val.map((item) => self.getPrefLabel(item.labels)).join(", ");
         }
         return name;
     });
@@ -61,8 +61,8 @@ export default function (params) {
                 const newItem = selection.map((id) => {
                     return {
                         labels: NAME_LOOKUP[id].labels,
-                        list_id: NAME_LOOKUP[id]['list_id'],
-                        uri: NAME_LOOKUP[id]['uri'],
+                        list_id: NAME_LOOKUP[id]["list_id"],
+                        uri: NAME_LOOKUP[id]["uri"],
                     };
                 });
                 self.value(newItem);
@@ -97,19 +97,19 @@ export default function (params) {
             url: arches.urls.controlled_list_filtered(
                 ko.unwrap(params.node.config.controlledList),
             ),
-            dataType: 'json',
+            dataType: "json",
             quietMillis: 250,
             data: function (requestParams) {
                 return {
-                    term: requestParams.term || '',
+                    term: requestParams.term || "",
                     flat: true,
                 };
             },
             processResults: function (data, requestParams) {
                 const items = data.items;
-                const term = (requestParams?.term || '').toLowerCase();
+                const term = (requestParams?.term || "").toLowerCase();
                 items.forEach((item) => {
-                    item['list_id'] = item.list_id;
+                    item["list_id"] = item.list_id;
                     item.uri = item.uri;
                     item.disabled = item.guide;
                     item.labels = item.values.filter((val) =>
@@ -129,7 +129,7 @@ export default function (params) {
             if (item.uri) {
                 const text =
                     self.getPrefLabel(item.labels) ||
-                    arches.translations.searching + '...';
+                    arches.translations.searching + "...";
                 NAME_LOOKUP[item.labels[0].list_item_id] = {
                     prefLabel: text,
                     labels: item.labels,
@@ -141,21 +141,22 @@ export default function (params) {
                         text +
                         '<span style="display:block;font-size:0.85em;opacity:0.6;">(' +
                         item.parent_path +
-                        ')</span>'
+                        ")</span>"
                     );
                 }
-                let indentation = '';
+                let indentation = "";
                 for (let i = 0; i < item.depth; i++) {
-                    indentation += '&nbsp;&nbsp;&nbsp;&nbsp;';
+                    indentation += "&nbsp;&nbsp;&nbsp;&nbsp;";
                 }
                 return indentation + text;
             }
         },
         templateSelection: function (item) {
-            if (!item.uri) { // option has a different shape when coming from initSelection vs templateResult
+            if (!item.uri) {
+                // option has a different shape when coming from initSelection vs templateResult
                 return item.text;
             } else {
-                return NAME_LOOKUP[item.labels[0].list_item_id]['prefLabel'];
+                return NAME_LOOKUP[item.labels[0].list_item_id]["prefLabel"];
             }
         },
         escapeMarkup: function (markup) {

--- a/arches_controlled_lists/templates/arches_urls.htm
+++ b/arches_controlled_lists/templates/arches_urls.htm
@@ -9,6 +9,7 @@
 <div class="arches-urls"
     controlled_lists="{% url 'controlled_lists' %}"
     controlled_list='(listid) => {return "{% url "controlled_list" "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" %}".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", listid)}'
+    controlled_list_filtered='(listid) => {return "{% url "filtered_controlled_list" "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" %}".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", listid)}'
     controlled_list_add="{% url 'controlled_list_add' %}"
     controlled_list_export="{% url 'controlled_list_export' %}"
     controlled_list_item='(itemid) => {return "{% url "controlled_list_item" "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" %}".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", itemid)}'

--- a/arches_controlled_lists/urls.py
+++ b/arches_controlled_lists/urls.py
@@ -88,7 +88,7 @@ urlpatterns = [
 
 
 # Ensure Arches core urls are superseded by project-level urls
-# urlpatterns.append(path("", include("arches.urls")))
+urlpatterns.append(path("", include("arches.urls")))
 
 # Adds URL pattern to serve media files during development
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/arches_controlled_lists/urls.py
+++ b/arches_controlled_lists/urls.py
@@ -4,6 +4,7 @@ from django.conf.urls.i18n import i18n_patterns
 from django.urls import include, path
 
 from arches_controlled_lists.views import (
+    FilteredListView,
     ListsView,
     ListView,
     ListExportView,
@@ -21,6 +22,11 @@ urlpatterns = [
         "api/controlled_list/<uuid:list_id>",
         ListView.as_view(),
         name="controlled_list",
+    ),
+    path(
+        "api/filtered_controlled_list/<uuid:list_id>",
+        FilteredListView.as_view(),
+        name="filtered_controlled_list",
     ),
     path("api/controlled_list", ListView.as_view(), name="controlled_list_add"),
     path(
@@ -82,7 +88,7 @@ urlpatterns = [
 
 
 # Ensure Arches core urls are superseded by project-level urls
-urlpatterns.append(path("", include("arches.urls")))
+# urlpatterns.append(path("", include("arches.urls")))
 
 # Adds URL pattern to serve media files during development
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/arches_controlled_lists/views.py
+++ b/arches_controlled_lists/views.py
@@ -209,12 +209,16 @@ class FilteredListView(APIBase):
         while current_id and current_id in item_map:
             parent = item_map[current_id]
             parent_labels = [
-                v for v in parent.get("values", [])
+                v
+                for v in parent.get("values", [])
                 if v.get("valuetype_id") == "prefLabel"
             ]
             label = next(
-                (lbl["value"] for lbl in parent_labels
-                 if lbl.get("language_id", lbl.get("languageid")) == lang),
+                (
+                    lbl["value"]
+                    for lbl in parent_labels
+                    if lbl.get("language_id", lbl.get("languageid")) == lang
+                ),
                 next((lbl["value"] for lbl in parent_labels), ""),
             )
             parts.append(label)
@@ -270,8 +274,10 @@ class FilteredListView(APIBase):
         if term:
             term_lower = term.lower()
             ordered = [
-                item for item in ordered
-                if not item.get("guide") and any(
+                item
+                for item in ordered
+                if not item.get("guide")
+                and any(
                     v.get("valuetype_id") == "prefLabel"
                     and term_lower in v.get("value", "").lower()
                     for v in item.get("values", [])

--- a/arches_controlled_lists/views.py
+++ b/arches_controlled_lists/views.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from http import HTTPStatus
 from uuid import UUID
 import filetype
@@ -199,6 +200,86 @@ class ListView(APIBase):
             )
         list_to_delete.delete()
         return JSONResponse(status=HTTPStatus.NO_CONTENT)
+
+
+class FilteredListView(APIBase):
+    def _get_parent_path(self, item, item_map, lang):
+        parts = []
+        current_id = item.get("parent_id")
+        while current_id and current_id in item_map:
+            parent = item_map[current_id]
+            parent_labels = [
+                v for v in parent.get("values", [])
+                if v.get("valuetype_id") == "prefLabel"
+            ]
+            label = next(
+                (lbl["value"] for lbl in parent_labels
+                 if lbl.get("language_id", lbl.get("languageid")) == lang),
+                next((lbl["value"] for lbl in parent_labels), ""),
+            )
+            parts.append(label)
+            current_id = parent.get("parent_id")
+        return " > ".join(reversed(parts))
+
+    def _walk(self, children_map, parent_id, depth, item_map, lang):
+        for child in children_map[parent_id]:
+            child["depth"] = depth
+            child["parent_path"] = self._get_parent_path(child, item_map, lang)
+            yield child
+            yield from self._walk(children_map, child["id"], depth + 1, item_map, lang)
+
+    def get(self, request, list_id):
+        """Returns a flat, hierarchically-ordered list with parent paths."""
+        term = request.GET.get("term", "")
+
+        try:
+            lst = List.objects.prefetch_related(*_prefetch_terms(request)).get(
+                pk=list_id
+            )
+        except List.DoesNotExist:
+            return JSONErrorResponse(status=HTTPStatus.NOT_FOUND)
+
+        flat = str_to_bool(request.GET.get("flat", "false"))
+        permitted = get_nodegroups_by_perm(request.user, "read_nodegroup")
+        serialized = lst.serialize(flat=flat, permitted_nodegroups=permitted)
+
+        if "items" not in serialized:
+            return JSONResponse(serialized)
+
+        items = serialized["items"]
+
+        item_map = {item["id"]: item for item in items}
+        children_map = defaultdict(list)
+        roots = []
+        for item in items:
+            pid = item.get("parent_id")
+            if pid and pid in item_map:
+                children_map[pid].append(item)
+            else:
+                roots.append(item)
+
+        lang = request.LANGUAGE_CODE
+        ordered = []
+
+        for root in roots:
+            root["depth"] = 0
+            root["parent_path"] = ""
+            ordered.append(root)
+            ordered.extend(self._walk(children_map, root["id"], 1, item_map, lang))
+
+        if term:
+            term_lower = term.lower()
+            ordered = [
+                item for item in ordered
+                if not item.get("guide") and any(
+                    v.get("valuetype_id") == "prefLabel"
+                    and term_lower in v.get("value", "").lower()
+                    for v in item.get("values", [])
+                )
+            ]
+
+        serialized["items"] = ordered
+        return JSONResponse(serialized)
 
 
 @method_decorator(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -621,3 +621,322 @@ class ListTests(TestCase):
         self.assertNotEqual(str(item_to_copy.pk), str(copied_item["id"]))
         self.assertEqual(copied_item["list_id"], str(self.list1.pk))
         self.assertEqual(len(copied_item.get("children", [])), 0)
+
+    # ListView error cases
+
+    def test_get_list_not_found(self):
+        self.client.force_login(self.admin)
+        response = self.client.get(
+            reverse("controlled_list", kwargs={"list_id": str(uuid.uuid4())}),
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND, response.content)
+
+    def test_patch_list_not_found(self):
+        self.client.force_login(self.admin)
+        response = self.client.patch(
+            reverse("controlled_list", kwargs={"list_id": str(uuid.uuid4())}),
+            {"name": "New Name"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND, response.content)
+
+    def test_patch_list_no_update_fields(self):
+        self.client.force_login(self.admin)
+        response = self.client.patch(
+            reverse("controlled_list", kwargs={"list_id": str(self.list1.pk)}),
+            {},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST, response.content)
+
+    def test_patch_list_name(self):
+        self.client.force_login(self.admin)
+        response = self.client.patch(
+            reverse("controlled_list", kwargs={"list_id": str(self.list2.pk)}),
+            {"name": "Renamed List"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT, response.content)
+        self.list2.refresh_from_db()
+        self.assertEqual(self.list2.name, "Renamed List")
+
+    def test_delete_list_not_found(self):
+        self.client.force_login(self.admin)
+        response = self.client.delete(
+            reverse("controlled_list", kwargs={"list_id": str(uuid.uuid4())}),
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND, response.content)
+
+    # FilteredListView tests
+
+    def test_filtered_list_view_basic(self):
+        self.client.force_login(self.admin)
+        response = self.client.get(
+            reverse("filtered_controlled_list", kwargs={"list_id": str(self.list2.pk)}),
+            QUERY_STRING="flat=true",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
+        result = response.json()
+        self.assertIn("items", result)
+        items = result["items"]
+        # All 5 items returned in hierarchical order with depth/parent_path
+        self.assertEqual(len(items), 5)
+        for item in items:
+            self.assertIn("depth", item)
+            self.assertIn("parent_path", item)
+        # Root item is first, has depth=0 and empty parent_path
+        self.assertEqual(items[0]["depth"], 0)
+        self.assertEqual(items[0]["parent_path"], "")
+        # Children follow the root and have depth=1
+        children = [i for i in items if i["depth"] == 1]
+        self.assertEqual(len(children), 4)
+
+    def test_filtered_list_view_with_term(self):
+        self.client.force_login(self.admin)
+        response = self.client.get(
+            reverse("filtered_controlled_list", kwargs={"list_id": str(self.list1.pk)}),
+            QUERY_STRING="flat=true&term=label0",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
+        result = response.json()
+        items = result["items"]
+        self.assertEqual(len(items), 1)
+        self.assertTrue(
+            any(
+                v.get("valuetype_id") == "prefLabel" and "label0" in v.get("value", "")
+                for v in items[0]["values"]
+            )
+        )
+
+    def test_filtered_list_view_no_match(self):
+        self.client.force_login(self.admin)
+        response = self.client.get(
+            reverse("filtered_controlled_list", kwargs={"list_id": str(self.list1.pk)}),
+            QUERY_STRING="flat=true&term=doesnotexist",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
+        self.assertEqual(response.json()["items"], [])
+
+    def test_filtered_list_view_not_found(self):
+        self.client.force_login(self.admin)
+        response = self.client.get(
+            reverse("filtered_controlled_list", kwargs={"list_id": str(uuid.uuid4())}),
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND, response.content)
+
+    # ListItemView additional error cases
+
+    def test_create_list_item_anonymous(self):
+        self.client.force_login(self.anonymous)
+        with self.assertLogs("django.request", level="WARNING"):
+            response = self.client.post(
+                reverse("controlled_list_item_add"),
+                {"list_id": str(self.list1.pk), "parent_id": None},
+                content_type="application/json",
+            )
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN, response.content)
+
+    def test_create_list_item_missing_keys(self):
+        self.client.force_login(self.admin)
+        # Omit parent_id to trigger KeyError in the view
+        response = self.client.post(
+            reverse("controlled_list_item_add"),
+            {"list_id": str(self.list1.pk)},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST, response.content)
+
+    def test_create_list_item_invalid_list(self):
+        self.client.force_login(self.admin)
+        response = self.client.post(
+            reverse("controlled_list_item_add"),
+            {"list_id": str(uuid.uuid4()), "parent_id": None},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST, response.content)
+
+    def test_patch_list_item_not_found(self):
+        self.client.force_login(self.admin)
+        response = self.client.patch(
+            reverse("controlled_list_item", kwargs={"item_id": str(uuid.uuid4())}),
+            {"uri": "https://example.com/new"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND, response.content)
+
+    def test_patch_list_item_no_fields(self):
+        self.client.force_login(self.admin)
+        item = self.list1.list_items.first()
+        response = self.client.patch(
+            reverse("controlled_list_item", kwargs={"item_id": str(item.pk)}),
+            {},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST, response.content)
+
+    def test_delete_list_item_not_found(self):
+        self.client.force_login(self.admin)
+        response = self.client.delete(
+            reverse("controlled_list_item", kwargs={"item_id": str(uuid.uuid4())}),
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND, response.content)
+
+    # ListItemValueView additional tests
+
+    def test_create_label(self):
+        self.client.force_login(self.admin)
+        item = self.list1.list_items.first()
+        data = {
+            "value": "new-label",
+            "language_id": self.first_language.code,
+            "valuetype_id": "altLabel",
+            "list_item_id": str(item.pk),
+        }
+        response = self.client.post(
+            reverse("controlled_list_item_value_add"),
+            data,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.CREATED, response.content)
+        result = response.json()
+        self.assertEqual(result["value"], "new-label")
+        self.assertEqual(result["valuetype_id"], "altLabel")
+
+    def test_update_label_not_found(self):
+        self.client.force_login(self.admin)
+        data = {
+            "value": "updated",
+            "valuetype_id": "altLabel",
+            "language_id": self.first_language.code,
+        }
+        response = self.client.put(
+            reverse(
+                "controlled_list_item_value",
+                kwargs={"value_id": str(uuid.uuid4())},
+            ),
+            data,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND, response.content)
+
+    def test_update_label_missing_keys(self):
+        self.client.force_login(self.admin)
+        alt_label = ListItemValue.objects.filter(valuetype_id="altLabel").first()
+        response = self.client.put(
+            reverse(
+                "controlled_list_item_value",
+                kwargs={"value_id": str(alt_label.pk)},
+            ),
+            {"value": "updated"},  # missing valuetype_id and language_id
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST, response.content)
+
+    def test_delete_label_not_found(self):
+        self.client.force_login(self.admin)
+        response = self.client.delete(
+            reverse(
+                "controlled_list_item_value",
+                kwargs={"value_id": str(uuid.uuid4())},
+            ),
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND, response.content)
+
+    # ListItemImageView additional tests
+
+    def test_delete_image_not_found(self):
+        self.client.force_login(self.admin)
+        response = self.client.delete(
+            reverse(
+                "controlled_list_item_image",
+                kwargs={"image_id": str(uuid.uuid4())},
+            ),
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND, response.content)
+
+    # ListItemImageMetadataView additional tests
+
+    def test_create_metadata(self):
+        self.client.force_login(self.admin)
+        item = self.list1.list_items.first()
+        temp_image = ListItemImage.objects.create(
+            list_item=item,
+            value="path/to/temp_image.png",
+            valuetype_id="image",
+        )
+        first_metadata_type = ListItemImageMetadata.MetadataChoices.choices[0][0]
+        data = {
+            "list_item_image_id": str(temp_image.pk),
+            "metadata_type": first_metadata_type,
+            "value": "Test metadata value",
+            "language_id": self.first_language.code,
+        }
+        response = self.client.post(
+            reverse("controlled_list_item_image_metadata_add"),
+            data,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.CREATED, response.content)
+
+    def test_update_metadata_not_found(self):
+        self.client.force_login(self.admin)
+        first_metadata_type = ListItemImageMetadata.MetadataChoices.choices[0][0]
+        data = {
+            "value": "Updated",
+            "language_id": self.first_language.code,
+            "metadata_type": first_metadata_type,
+        }
+        response = self.client.put(
+            reverse(
+                "controlled_list_item_image_metadata",
+                kwargs={"metadata_id": str(uuid.uuid4())},
+            ),
+            data,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND, response.content)
+
+    def test_update_metadata_missing_keys(self):
+        self.client.force_login(self.admin)
+        metadata = self.image.list_item_image_metadata.first()
+        response = self.client.put(
+            reverse(
+                "controlled_list_item_image_metadata",
+                kwargs={"metadata_id": str(metadata.pk)},
+            ),
+            {"value": "Updated"},  # missing language_id and metadata_type
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST, response.content)
+
+    def test_delete_metadata_not_found(self):
+        self.client.force_login(self.admin)
+        response = self.client.delete(
+            reverse(
+                "controlled_list_item_image_metadata",
+                kwargs={"metadata_id": str(uuid.uuid4())},
+            ),
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND, response.content)
+
+    # ListExportView additional tests
+
+    def test_export_skos_empty_list_ids(self):
+        self.client.force_login(self.admin)
+        with self.assertLogs("django.request", level="WARNING"):
+            response = self.client.post(
+                reverse("controlled_list_export"),
+                {"list_ids": []},
+                content_type="application/json",
+            )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST, response.content)
+
+    def test_export_skos_anonymous(self):
+        self.client.force_login(self.anonymous)
+        with self.assertLogs("django.request", level="WARNING"):
+            response = self.client.post(
+                reverse("controlled_list_export"),
+                {"list_ids": [str(self.list1.pk)]},
+                content_type="application/json",
+            )
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN, response.content)


### PR DESCRIPTION
Adds filter to reference-select widget. Shows parent hierarchy for hierarchical list item results

closes: #138

Implemented by @braydencstratusadv
