### PR TITLE
Implements free-form search of reference datatypes

### DIFF
--- a/arches_controlled_lists/datatypes/datatypes.py
+++ b/arches_controlled_lists/datatypes/datatypes.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext as _
 from arches.app.datatypes.base import BaseDataType
 from arches.app.models.models import Node
 from arches.app.models.graph import GraphValidationError
-from arches.app.search.elasticsearch_dsl_builder import Exists, Term
+from arches.app.search.elasticsearch_dsl_builder import Bool, Exists, Term
 
 from arches_controlled_lists.models import ListItem
 
@@ -407,6 +407,43 @@ class ReferenceDataType(BaseDataType):
             values_list = value.get("val", [])
             if value["op"] == "null" or value["op"] == "not_null":
                 self.append_null_search_filters(value, node, query, request)
+            elif value["op"] in ["like", "startswith", "like_uri", "startswith_uri"]:
+                search_string = values_list if isinstance(values_list, str) else ""
+                if search_string:
+                    controlled_list_id = node.config.get("controlledList")
+                    if value["op"] == "like":
+                        item_filter = {
+                            "list_item_values__value__icontains": search_string,
+                        }
+                    elif value["op"] == "startswith":
+                        item_filter = {
+                            "list_item_values__value__istartswith": search_string,
+                        }
+                    elif value["op"] == "like_uri":
+                        item_filter = {
+                            "uri__icontains": search_string,
+                        }
+                    elif value["op"] == "startswith_uri":
+                        item_filter = {
+                            "uri__istartswith": search_string,
+                        }
+                    if controlled_list_id:
+                        item_filter["list_id"] = controlled_list_id
+
+                    matching_items = ListItem.objects.filter(**item_filter)
+                    child_uris = []
+                    for item in matching_items:
+                        item.get_child_uris(uris=child_uris)
+
+                    if child_uris:
+                        uri_field = f"tiles.data.{str(node.pk)}.uri"
+                        sub_query = Bool()
+                        for uri in set(child_uris):
+                            sub_query.should(Term(field=uri_field, term=uri))
+                        sub_query.dsl["bool"]["minimum_should_match"] = 1
+                        query.must(sub_query)
+                    else:
+                        query.must(Term(field="resourceinstanceid", term="_no_match_"))
             elif values_list:
                 child_uris = []
                 for val in values_list:

--- a/arches_controlled_lists/media/js/viewmodels/reference-select.js
+++ b/arches_controlled_lists/media/js/viewmodels/reference-select.js
@@ -1,60 +1,75 @@
-import $ from 'jquery';
-import ko from 'knockout';
-import koMapping from 'knockout-mapping';
-import arches from 'arches';
-import WidgetViewModel from 'viewmodels/widget';
+import $ from "jquery";
+import ko from "knockout";
+import koMapping from "knockout-mapping";
+import arches from "arches";
+import WidgetViewModel from "viewmodels/widget";
 
-export default function(params) {
+export default function (params) {
     const NAME_LOOKUP = {};
     var self = this;
 
-    params.configKeys = ['placeholder', 'defaultValue'];
+    params.configKeys = ["placeholder", "defaultValue"];
     this.multiple = !!ko.unwrap(params.node.config.multiValue);
-    this.displayName = ko.observable('');
+    this.displayName = ko.observable("");
     this.selectionValue = ko.observable([]); // formatted version of this.value that select2 can use
     this.activeLanguage = arches.activeLanguage;
 
     WidgetViewModel.apply(this, [params]);
 
-    this.getPrefLabel = function(labels){
-        return koMapping.toJS(labels)?.find(
-            label => label.language_id === arches.activeLanguage && label.valuetype_id === 'prefLabel'
-        )?.value || arches.translations.unlabeledItem;
-    }; 
-
-    this.isLabel = function (value) {
-        return ['prefLabel', 'altLabel'].includes(value.valuetype_id);
+    this.getPrefLabel = function (labels) {
+        return (
+            koMapping
+                .toJS(labels)
+                ?.find(
+                    (label) =>
+                        label.language_id === arches.activeLanguage &&
+                        label.valuetype_id === "prefLabel",
+                )?.value || arches.translations.unlabeledItem
+        );
     };
 
-    this.displayValue = ko.computed(function() {
+    this.isLabel = function (value) {
+        return ["prefLabel", "altLabel"].includes(value.valuetype_id);
+    };
+
+    this.displayValue = ko.computed(function () {
         const val = self.value();
         let name = null;
         if (val) {
-            name = val.map(item => self.getPrefLabel(item.labels)).join(", ");
+            if (typeof val === "string") {
+                // This is only when using the "like" function of advanced search
+                name = val;
+            } else {
+                name = val
+                    .map((item) => self.getPrefLabel(item.labels))
+                    .join(", ");
+            }
         }
         return name;
     });
 
-    this.valueAndSelectionDiffer = function(value, selection) {
+    this.valueAndSelectionDiffer = function (value, selection) {
         if (!(ko.unwrap(value) instanceof Array)) {
             return true;
         }
-        const valueIds = ko.unwrap(value).map(val=>{
+        const valueIds = ko.unwrap(value).map((val) => {
             const listItemLabels = ko.unwrap(val.labels);
             return ko.unwrap(listItemLabels[0]?.list_item_id);
         });
         return JSON.stringify(selection) !== JSON.stringify(valueIds);
     };
 
-    this.selectionValue.subscribe(selection => {
+    this.selectionValue.subscribe((selection) => {
         if (selection) {
-            if (!(selection instanceof Array)) { selection = [selection]; }
+            if (!(selection instanceof Array)) {
+                selection = [selection];
+            }
             if (self.valueAndSelectionDiffer(self.value, selection)) {
-                const newItem = selection.map(id => {
+                const newItem = selection.map((id) => {
                     return {
-                        "labels": NAME_LOOKUP[id].labels,
-                        "list_id": NAME_LOOKUP[id]["list_id"],
-                        "uri": NAME_LOOKUP[id]["uri"],
+                        labels: NAME_LOOKUP[id].labels,
+                        list_id: NAME_LOOKUP[id]["list_id"],
+                        uri: NAME_LOOKUP[id]["uri"],
                     };
                 });
                 self.value(newItem);
@@ -64,12 +79,14 @@ export default function(params) {
         }
     });
 
-    this.value.subscribe(val => {
+    this.value.subscribe((val) => {
         if (val?.length) {
-            self.selectionValue(val.map(item=>{
-                const listItemLabels = ko.unwrap(item.labels);
-                return ko.unwrap(listItemLabels[0]?.list_item_id);
-            }));
+            self.selectionValue(
+                val.map((item) => {
+                    const listItemLabels = ko.unwrap(item.labels);
+                    return ko.unwrap(listItemLabels[0]?.list_item_id);
+                }),
+            );
         } else {
             self.selectionValue(null);
         }
@@ -84,78 +101,85 @@ export default function(params) {
         placeholder: self.placeholder,
         allowClear: true,
         ajax: {
-            url: arches.urls.controlled_list(ko.unwrap(params.node.config.controlledList)),
-            dataType: 'json',
+            url: arches.urls.controlled_list(
+                ko.unwrap(params.node.config.controlledList),
+            ),
+            dataType: "json",
             quietMillis: 250,
-            data: function(requestParams) {
-
+            data: function (requestParams) {
                 return {
-                    flat: true
+                    flat: true,
                 };
             },
-            processResults: function(data) {
-                const items = data.items; 
-                items.forEach(item => {
+            processResults: function (data) {
+                const items = data.items;
+                items.forEach((item) => {
                     item["list_id"] = item.list_id;
                     item.uri = item.uri;
                     item.disabled = item.guide;
-                    item.labels = item.values.filter(val => self.isLabel(val));
+                    item.labels = item.values.filter((val) =>
+                        self.isLabel(val),
+                    );
                 });
                 return {
-                    "results": items,
-                    "pagination": {
-                        "more": false
-                    }
+                    results: items,
+                    pagination: {
+                        more: false,
+                    },
                 };
-            }
+            },
         },
-        templateResult: function(item) {
-            let indentation = '';
+        templateResult: function (item) {
+            let indentation = "";
             for (let i = 0; i < item.depth; i++) {
-                indentation += '&nbsp;&nbsp;&nbsp;&nbsp;';
+                indentation += "&nbsp;&nbsp;&nbsp;&nbsp;";
             }
 
             if (item.uri) {
-                const text = self.getPrefLabel(item.labels) || arches.translations.searching + '...';
+                const text =
+                    self.getPrefLabel(item.labels) ||
+                    arches.translations.searching + "...";
                 NAME_LOOKUP[item.labels[0].list_item_id] = {
-                    "prefLabel": text,
-                    "labels": item.labels,
-                    "list_id": item.list_id,
-                    "uri": item.uri,
+                    prefLabel: text,
+                    labels: item.labels,
+                    list_id: item.list_id,
+                    uri: item.uri,
                 };
                 return indentation + text;
             }
         },
-        templateSelection: function(item) {
-            if (!item.uri) { // option has a different shape when coming from initSelection vs templateResult
+        templateSelection: function (item) {
+            if (!item.uri) {
+                // option has a different shape when coming from initSelection vs templateResult
                 return item.text;
             } else {
                 return NAME_LOOKUP[item.labels[0].list_item_id]["prefLabel"];
             }
         },
-        escapeMarkup: function(markup) { return markup; },
+        escapeMarkup: function (markup) {
+            return markup;
+        },
         initComplete: false,
-        initSelection: function(el, callback) {
-
-            const setSelectionData = function(data) {
+        initSelection: function (el, callback) {
+            const setSelectionData = function (data) {
                 const valueData = koMapping.toJS(self.value());
 
-                valueData.forEach(function(value) {
+                valueData.forEach(function (value) {
                     NAME_LOOKUP[value.labels[0].list_item_id] = {
-                            "prefLabel": self.getPrefLabel(value.labels),
-                            "labels": value.labels,
-                            "list_id": value.list_id,
-                            "uri": value.uri,
-                        };
+                        prefLabel: self.getPrefLabel(value.labels),
+                        labels: value.labels,
+                        list_id: value.list_id,
+                        uri: value.uri,
+                    };
                 });
-    
-                if(!self.select2Config.initComplete){
-                    valueData.forEach(function(data) {
+
+                if (!self.select2Config.initComplete) {
+                    valueData.forEach(function (data) {
                         const option = new Option(
                             self.getPrefLabel(data.labels),
                             data.labels[0].list_item_id,
-                            true, 
-                            true
+                            true,
+                            true,
                         );
                         $(el).append(option);
                         self.selectionValue().push(data.labels[0].list_item_id);
@@ -170,10 +194,8 @@ export default function(params) {
             } else {
                 callback([]);
             }
-
-        }
+        },
     };
     this.select2ConfigMulti = { ...this.select2Config };
     this.select2ConfigMulti.multiple = true;
-
-};
+}

--- a/arches_controlled_lists/media/js/views/components/datatypes/reference.js
+++ b/arches_controlled_lists/media/js/views/components/datatypes/reference.js
@@ -1,58 +1,78 @@
-import ko from 'knockout';
-import arches from 'arches';
-import Cookies from 'js-cookie';
-import referenceSelect from 'viewmodels/reference-select';
-import referenceDatatypeTemplate from 'templates/views/components/datatypes/reference.htm';
+import ko from "knockout";
+import arches from "arches";
+import Cookies from "js-cookie";
+import referenceSelect from "viewmodels/reference-select";
+import referenceDatatypeTemplate from "templates/views/components/datatypes/reference.htm";
 
-const viewModel = function(params) {
+const viewModel = function (params) {
     const self = this;
     this.search = params.search;
 
     if (this.search) {
         var filter = params.filterValue();
         params.config = ko.observable({
-            controlledList:[],
+            controlledList: [],
             placeholder: arches.translations.selectAnOption,
-            multiValue: true
+            multiValue: true,
         });
-        this.op = ko.observable(filter.op || 'eq');
-        this.searchValue = ko.observable(filter.val || '');
+        this.op = ko.observable(filter.op || "eq");
+        this.searchValue = ko.observable(filter.val || "");
+        this.searchString = ko.observable(
+            filter.val && typeof filter.val === "string" ? filter.val : "",
+        );
         this.node = params.node;
         params.value = this.searchValue;
         referenceSelect.apply(this, [params]);
 
-        this.filterValue = ko.computed(function() {
+        this.isStringOp = ko.computed(function () {
+            return [
+                "like",
+                "startswith",
+                "like_uri",
+                "startswith_uri",
+            ].includes(self.op());
+        });
+
+        this.op.subscribe(function (newOp) {
+            if (newOp === "like") {
+                self.searchValue("");
+            } else {
+                self.searchString("");
+            }
+        });
+
+        this.filterValue = ko.computed(function () {
             return {
                 op: self.op(),
-                val: reduceReferenceShape(self.searchValue())
+                val: self.isStringOp()
+                    ? self.searchString()
+                    : reduceReferenceShape(self.searchValue()),
             };
         });
         params.filterValue(this.filterValue());
-        this.filterValue.subscribe(function(val) {
+        this.filterValue.subscribe(function (val) {
             params.filterValue(val);
         });
-    }
-
-    else {
+    } else {
         this.controlledList = params.config.controlledList;
         this.multiValue = params.config.multiValue;
         this.controlledLists = ko.observable();
-        this.getControlledLists = async function() {
+        this.getControlledLists = async function () {
             const response = await fetch(arches.urls.controlled_lists, {
-                method: 'GET',
-                credentials: 'include',
+                method: "GET",
+                credentials: "include",
                 headers: {
-                    "X-CSRFToken": Cookies.get('csrftoken')
+                    "X-CSRFToken": Cookies.get("csrftoken"),
                 },
             });
             if (response.ok) {
                 return await response.json();
             } else {
-                console.error('Failed to fetch controlled lists');
+                console.error("Failed to fetch controlled lists");
             }
         };
-        
-        this.init = async function() {
+
+        this.init = async function () {
             const lists = await this.getControlledLists();
             this.controlledLists(lists?.controlled_lists);
         };
@@ -67,21 +87,20 @@ const viewModel = function(params) {
             if (Array.isArray(items)) {
                 const slimmedObj = items.map((item) => {
                     return {
-                        "labels": item.labels,
-                        "uri": item.uri,
-                    }
+                        labels: item.labels,
+                        uri: item.uri,
+                    };
                 });
                 return slimmedObj;
             } else {
                 return [items];
             }
         }
-        return '';
-    };
+        return "";
+    }
 };
 
-
-export default ko.components.register('reference-datatype-config', {
+export default ko.components.register("reference-datatype-config", {
     viewModel: viewModel,
     template: referenceDatatypeTemplate,
 });

--- a/arches_controlled_lists/templates/javascript.htm
+++ b/arches_controlled_lists/templates/javascript.htm
@@ -13,7 +13,6 @@
     select-a-controlled-list='{% trans "Select a controlled list" as selectAControlledList %} "{{ selectAControlledList|escapejs }}"'
     multiple-values='{% trans "Multiple Values" as multipleValues %} "{{ multipleValues|escapejs }}"'
     allow-selection-of-multiple-items='{% trans "Allow selection of multiple items" as allowSelectionOfMultipleItems %} "{{ allowSelectionOfMultipleItems|escapejs }}"'
-    like='{% trans "like" as like %} "{{ like|escapejs }}"'
     starts-with='{% trans "starts with" as startsWith %} "{{ startsWith|escapejs }}"'
     uri-like='{% trans "uri like" as uriLike %} "{{ uriLike|escapejs }}"'
     uri-starts-with='{% trans "uri starts with" as uriStartsWith %} "{{ uriStartsWith|escapejs }}"'

--- a/arches_controlled_lists/templates/javascript.htm
+++ b/arches_controlled_lists/templates/javascript.htm
@@ -13,5 +13,9 @@
     select-a-controlled-list='{% trans "Select a controlled list" as selectAControlledList %} "{{ selectAControlledList|escapejs }}"'
     multiple-values='{% trans "Multiple Values" as multipleValues %} "{{ multipleValues|escapejs }}"'
     allow-selection-of-multiple-items='{% trans "Allow selection of multiple items" as allowSelectionOfMultipleItems %} "{{ allowSelectionOfMultipleItems|escapejs }}"'
+    like='{% trans "like" as like %} "{{ like|escapejs }}"'
+    starts-with='{% trans "starts with" as startsWith %} "{{ startsWith|escapejs }}"'
+    uri-like='{% trans "uri like" as uriLike %} "{{ uriLike|escapejs }}"'
+    uri-starts-with='{% trans "uri starts with" as uriStartsWith %} "{{ uriStartsWith|escapejs }}"'
 ></div>
 {% endblock arches_translations %}

--- a/arches_controlled_lists/templates/views/components/datatypes/reference.htm
+++ b/arches_controlled_lists/templates/views/components/datatypes/reference.htm
@@ -7,17 +7,17 @@
         <span data-bind="text: $root.translations.controlledList"></span>
     </div>
     <!-- ko if: $data.controlledLists() -->
-        <select 
+        <select
             data-bind="
-                options: $data.controlledLists, 
-                optionsText: 'name', 
-                optionsValue: 'id', 
+                options: $data.controlledLists,
+                optionsText: 'name',
+                optionsValue: 'id',
                 select2Query: {
                     select2Config:{
                         disable: false,
                         value: $data.controlledList,
                         allowClear: true,
-                        placeholder: $root.translations.selectAControlledList, 
+                        placeholder: $root.translations.selectAControlledList,
                 }},
                 attr: {'data-label': $root.translations.controlledList}
             "
@@ -49,6 +49,10 @@
                 data: [
                     { text: $root.translations.equals, id: 'eq' },
                     { text: $root.translations.not, id: '!eq' },
+                    { text: $root.translations.like, id: 'like' },
+                    { text: $root.translations.startsWith, id: 'startswith' },
+                    { text: $root.translations.uriLike, id: 'like_uri' },
+                    { text: $root.translations.uriStartsWith, id: 'startswith_uri' },
                     { text: $root.translations.hasNoValue, id: 'null' },
                     { text: $root.translations.hasAnyValue, id: 'not_null' },
                     { text: $root.translations.hasAnyListValue, id: 'in_list_any' },
@@ -60,6 +64,23 @@
     </select>
 </div>
 
+<!-- ko if: isStringOp() -->
+<div class="col-md-8 col-lg-9">
+    <input
+        type="text"
+        class="form-control input-lg"
+        style="height: 36px;"
+        data-bind="
+            attr: {
+                placeholder: 'Enter a search pattern...',
+                'aria-label': node.label
+            },
+            textInput: searchString
+        "
+    >
+</div>
+<!-- /ko -->
+<!-- ko ifnot: isStringOp() -->
 <div class="col-md-8 col-lg-9" data-bind="visible: op() !== 'null' && op() !== 'not_null'">
     <!-- ko if: !ko.unwrap(op).includes('in_list') -->
     <select style="display:inline-block;"
@@ -82,4 +103,5 @@
     </select>
     <!-- /ko -->
 </div>
+<!-- /ko -->
 <!-- /ko -->

--- a/tests/reference_datatype_tests.py
+++ b/tests/reference_datatype_tests.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 from django.test import TestCase
 from arches.app.datatypes.datatypes import DataTypeFactory
+from arches.app.models.graph import GraphValidationError
 from arches.app.models.tile import Tile
 from arches.app.models.models import Node, TileModel
 from arches.app.search.elasticsearch_dsl_builder import Bool
@@ -431,3 +432,358 @@ class ReferenceDataTypeTests(TestCase):
         mock_value = {"op": "null", "val": None}
         reference.append_search_filters(mock_value, mock_node, mock_query, Mock())
         mock_query.should.assert_called()
+
+    def test_to_python_directly(self):
+        reference = ReferenceDataType()
+
+        # Falsy inputs → None
+        self.assertIsNone(reference.to_python(None))
+        self.assertIsNone(reference.to_python([]))
+
+        # Valid reference
+        list_item_id = uuid.uuid4()
+        result = reference.to_python(
+            [
+                {
+                    "uri": "https://example.com/1",
+                    "labels": [
+                        {
+                            "id": str(uuid.uuid4()),
+                            "value": "Test",
+                            "language_id": "en",
+                            "valuetype_id": "prefLabel",
+                            "list_item_id": str(list_item_id),
+                        }
+                    ],
+                    "list_id": str(uuid.uuid4()),
+                }
+            ]
+        )
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], Reference)
+        self.assertIsInstance(result[0].labels[0], ReferenceLabel)
+        # list_item_id is stored as the raw string value passed in
+        self.assertEqual(result[0].labels[0].list_item_id, str(list_item_id))
+
+    def test_serialize(self):
+        reference = ReferenceDataType()
+
+        # None → None
+        self.assertIsNone(reference.serialize(None))
+
+        # Reference dataclass → asdict
+        ref = Reference(
+            uri="https://example.com/ref",
+            labels=[
+                ReferenceLabel(
+                    id=uuid.uuid4(),
+                    value="Test",
+                    language_id="en",
+                    valuetype_id="prefLabel",
+                    list_item_id=uuid.uuid4(),
+                )
+            ],
+            list_id=uuid.uuid4(),
+        )
+        result = reference.serialize([ref])
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["uri"], ref.uri)
+        self.assertEqual(len(result[0]["labels"]), 1)
+
+        # Plain dict → spread passthrough
+        raw = {"uri": "https://example.com/dict", "labels": [], "list_id": "abc"}
+        result2 = reference.serialize([raw])
+        self.assertEqual(result2[0]["uri"], raw["uri"])
+
+    def test_validate_node(self):
+        reference = ReferenceDataType()
+        node = Mock()
+
+        # Valid UUID → no exception
+        node.config = {"controlledList": str(uuid.uuid4())}
+        reference.validate_node(node)
+
+        # Missing key → raises
+        node.config = {}
+        with self.assertRaises(GraphValidationError):
+            reference.validate_node(node)
+
+        # None value → raises
+        node.config = {"controlledList": None}
+        with self.assertRaises(GraphValidationError):
+            reference.validate_node(node)
+
+        # Invalid UUID string → ValueError propagates (only TypeError/KeyError are caught)
+        node.config = {"controlledList": "not-a-uuid"}
+        with self.assertRaises(ValueError):
+            reference.validate_node(node)
+
+    def test_transform_exception(self):
+        # TypeError: missing required args
+        e = TypeError("__init__() missing 1 required positional argument: 'uri'")
+        result = ReferenceDataType.transform_exception(e)
+        self.assertEqual(result["type"], "ERROR")
+        self.assertIn("Missing required value(s):", result["message"])
+        self.assertIn("Invalid Reference Datatype Value", result["title"])
+
+        # TypeError: unexpected keyword argument
+        e = TypeError("__init__() got an unexpected keyword argument 'garbage'")
+        result = ReferenceDataType.transform_exception(e)
+        self.assertIn("Unexpected value:", result["message"])
+
+        # TypeError: no args → falls through to "Unknown error"
+        e = TypeError()
+        result = ReferenceDataType.transform_exception(e)
+        self.assertIn("Unknown error", result["message"])
+
+        # ValueError with message
+        e = ValueError("Custom error message")
+        result = ReferenceDataType.transform_exception(e)
+        self.assertEqual(result["message"], "Custom error message")
+
+        # ValueError: no args → "Unknown error"
+        e = ValueError()
+        result = ReferenceDataType.transform_exception(e)
+        self.assertIn("Unknown error", result["message"])
+
+        # Other exception type → "Unknown error"
+        e = RuntimeError("something unexpected")
+        result = ReferenceDataType.transform_exception(e)
+        self.assertIn("Unknown error", result["message"])
+
+    def test_validate_multivalue_nodeid_lookup(self):
+        reference = ReferenceDataType()
+        node = ListTests.node_using_list1
+
+        parsed = reference.to_python(
+            [
+                {
+                    "uri": "https://example.com",
+                    "labels": [
+                        {
+                            "id": str(uuid.uuid4()),
+                            "value": "Test",
+                            "language_id": "en",
+                            "valuetype_id": "prefLabel",
+                            "list_item_id": str(uuid.uuid4()),
+                        }
+                    ],
+                    "list_id": str(uuid.uuid4()),
+                }
+            ]
+        )
+
+        # Valid nodeid → fetches node, single value is allowed on non-multiValue node
+        reference.validate_multivalue(parsed, None, str(node.pk))
+
+        # Nonexistent nodeid → Node.DoesNotExist caught, returns without raising
+        reference.validate_multivalue(parsed, None, str(uuid.uuid4()))
+
+        # Neither node nor nodeid → raises ValueError
+        with self.assertRaises(ValueError):
+            reference.validate_multivalue(parsed, None, None)
+
+        # Two references on a non-multiValue node → raises ValueError
+        two_refs = parsed + parsed
+        with self.assertRaises(ValueError):
+            reference.validate_multivalue(two_refs, node, None)
+
+    def test_lookup_listitem_from_label(self):
+        reference = ReferenceDataType()
+        list1_pk = str(ListTests.list1.pk)
+
+        # Valid lookup returns the expected item
+        result = reference.lookup_listitem_from_label("label1-pref", list1_pk)
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, ListItem)
+
+        # Empty value → None
+        self.assertIsNone(reference.lookup_listitem_from_label("", list1_pk))
+
+        # None list_id → None
+        self.assertIsNone(reference.lookup_listitem_from_label("label1-pref", None))
+
+        # Nonexistent label → None
+        self.assertIsNone(
+            reference.lookup_listitem_from_label("xyz_no_such_label", list1_pk)
+        )
+
+    def test_transform_value_for_tile_uuid_string(self):
+        reference = DataTypeFactory().get_instance("reference")
+        config = {"controlledList": str(ListTests.list1.pk)}
+
+        # UUID string for a known item → resolved to tile value
+        item = ListTests.list1.list_items.get(sortorder=0)
+        result = reference.transform_value_for_tile([str(item.pk)], **config)
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIn("uri", result[0])
+        self.assertIn("labels", result[0])
+
+        # UUID string for unknown item → not found → empty list
+        result_not_found = reference.transform_value_for_tile(
+            [str(uuid.uuid4())], **config
+        )
+        self.assertEqual(result_not_found, [])
+
+        # Reference object → passes through as asdict
+        ref = Reference(
+            uri="https://example.com/passthrough",
+            labels=[
+                ReferenceLabel(
+                    id=uuid.uuid4(),
+                    value="Passthrough",
+                    language_id="en",
+                    valuetype_id="prefLabel",
+                    list_item_id=uuid.uuid4(),
+                )
+            ],
+            list_id=uuid.uuid4(),
+        )
+        result_ref = reference.transform_value_for_tile([ref], **config)
+        self.assertEqual(len(result_ref), 1)
+        self.assertEqual(result_ref[0]["uri"], ref.uri)
+
+    def test_transform_export_values_extended(self):
+        reference = DataTypeFactory().get_instance("reference")
+        node = ListTests.node_using_list1
+        mock_tile = self.get_mock_tile()
+        node_value = mock_tile.data[str(node.pk)]
+
+        # None value → implicit None return
+        self.assertIsNone(reference.transform_export_values(None))
+
+        # concept_export_value_type="" → treated as "label"
+        self.assertEqual(
+            reference.transform_export_values(node_value, concept_export_value_type=""),
+            "label0-pref",
+        )
+
+        # concept_export_value_type=None → treated as "label"
+        self.assertEqual(
+            reference.transform_export_values(
+                node_value, concept_export_value_type=None
+            ),
+            "label0-pref",
+        )
+
+    def test_get_details_none(self):
+        reference = DataTypeFactory().get_instance("reference")
+
+        # None → None
+        self.assertIsNone(reference.get_details(None))
+
+        # Empty list → None (hits `else: return None` branch)
+        self.assertIsNone(reference.get_details([]))
+
+    def test_get_details_with_datatype_context(self):
+        reference = DataTypeFactory().get_instance("reference")
+        node = ListTests.node_using_list1
+        mock_tile = self.get_mock_tile()
+        value = mock_tile.data[str(node.pk)]
+
+        list_item_id = uuid.UUID(value[0]["labels"][0]["list_item_id"])
+        item = (
+            ListItem.objects.filter(pk=list_item_id)
+            .with_list_item_labels()
+            .prefetch_related("children")
+            .first()
+        )
+
+        # Item provided in context → taken from context rather than fetched separately
+        details = reference.get_details(value, datatype_context=[item])
+        self.assertEqual(len(details), 1)
+        self.assertIn("list_item_id", details[0])
+
+    def test_default_es_mapping(self):
+        reference = ReferenceDataType()
+        mapping = reference.default_es_mapping()
+        self.assertIn("properties", mapping)
+        self.assertEqual(mapping["properties"]["uri"]["type"], "keyword")
+        self.assertEqual(mapping["properties"]["id"]["type"], "keyword")
+        self.assertIn("labels", mapping["properties"])
+
+    def test_append_search_filters_text_ops(self):
+        reference = ReferenceDataType()
+        mock_node = Mock(Node)
+        mock_node.config = {"controlledList": str(ListTests.list1.pk)}
+        mock_query = Mock()
+
+        # Ops that search by label value or URI and find matches
+        for op, term in [
+            ("like", "label1"),
+            ("startswith", "label1"),
+            ("like_uri", "archesproject"),
+            ("startswith_uri", "https://archesproject"),
+        ]:
+            with self.subTest(op=op):
+                mock_query.reset_mock()
+                mock_query.must = Mock()
+                reference.append_search_filters(
+                    {"op": op, "val": term}, mock_node, mock_query, Mock()
+                )
+                mock_query.must.assert_called()
+
+        # No matching items → must called with _no_match_ sentinel
+        mock_query.reset_mock()
+        mock_query.must = Mock()
+        reference.append_search_filters(
+            {"op": "like", "val": "xyz_absolutely_no_match_xyz"},
+            mock_node,
+            mock_query,
+            Mock(),
+        )
+        mock_query.must.assert_called()
+
+    def test_append_search_filters_not_null(self):
+        reference = ReferenceDataType()
+        mock_node = Mock(Node)
+        mock_query = Mock()
+        # Should delegate to append_null_search_filters without raising
+        reference.append_search_filters(
+            {"op": "not_null", "val": None}, mock_node, mock_query, Mock()
+        )
+
+    def test_append_search_filters_empty_val(self):
+        reference = ReferenceDataType()
+        mock_node = Mock(Node)
+        mock_query = Mock()
+        # Empty val list → falls through without calling should/must
+        reference.append_search_filters(
+            {"op": "eq", "val": []}, mock_node, mock_query, Mock()
+        )
+        mock_query.should.assert_not_called()
+        mock_query.must.assert_not_called()
+
+    def test_append_search_filters_missing_op(self):
+        reference = ReferenceDataType()
+        mock_node = Mock(Node)
+        mock_query = Mock()
+        # KeyError on missing "op" is caught silently
+        reference.append_search_filters({"val": []}, mock_node, mock_query, Mock())
+
+    def test_append_to_document_provisional(self):
+        datatype = DataTypeFactory().get_instance("reference")
+        tile = TileModel(nodegroup_id=uuid.uuid4())
+        document = {"references": [], "strings": []}
+        ref = Reference(
+            uri="http://example.com/provisional",
+            labels=[
+                ReferenceLabel(
+                    id=uuid.uuid4(),
+                    value="Provisional Label",
+                    language_id="en",
+                    valuetype_id="prefLabel",
+                    list_item_id=uuid.uuid4(),
+                )
+            ],
+            list_id=uuid.uuid4(),
+        )
+        nodevalue = datatype.serialize([ref])
+        datatype.append_to_document(
+            document, nodevalue, uuid.uuid4(), tile, provisional=True
+        )
+        self.assertTrue(document["references"][0]["provisional"])
+        self.assertTrue(document["strings"][0]["provisional"])


### PR DESCRIPTION
Adds the ability to search reference datatypes using a free-form string in the following ways. All searches are case-insensitive:
- by value `like` or `starts with`
- by uir `like` or `starts with`

closes #176

Authored by @braydencstratusadv, extended by @bferguso 