### PR TITLE
Improve validation performance

### DIFF
--- a/arches_controlled_lists/datatypes/datatypes.py
+++ b/arches_controlled_lists/datatypes/datatypes.py
@@ -89,14 +89,27 @@ class ReferenceDataType(BaseDataType):
         strict=False,
         **kwargs,
     ):
+        errors = []
         try:
             parsed = self.to_python(value)
-            self.validate_pref_labels(parsed)
-            self.validate_list_item_consistency(parsed)
-            self.validate_multivalue(parsed, node, nodeid)
+            try:
+                self.validate_pref_labels(parsed)
+            except Exception as e:
+                errors.append(self.transform_exception(e))
+
+            try:
+                self.validate_list_item_consistency(parsed)
+            except Exception as e:
+                errors.append(self.transform_exception(e))
+
+            try:
+                self.validate_multivalue(parsed, node, nodeid)
+            except Exception as e:
+                return [self.transform_exception(e)]
+
         except Exception as e:
             return [self.transform_exception(e)]
-        return []
+        return errors
 
     def validate_pref_labels(self, references: list[Reference] | None):
         if not references:

--- a/arches_controlled_lists/datatypes/datatypes.py
+++ b/arches_controlled_lists/datatypes/datatypes.py
@@ -5,7 +5,7 @@ from typing import Iterable, Mapping
 
 from django.db.models import F, JSONField
 from django.utils.translation import gettext as _
-from rdflib import Graph, Literal, Namespace, URIRef
+from rdflib import Graph, Literal, URIRef
 from rdflib.namespace import RDF, RDFS
 
 from arches.app.datatypes.base import BaseDataType

--- a/arches_controlled_lists/datatypes/datatypes.py
+++ b/arches_controlled_lists/datatypes/datatypes.py
@@ -47,6 +47,7 @@ class Reference:
 
 class ReferenceDataType(BaseDataType):
     model_field = ReferenceField(null=True)
+    _node_cache: dict[str, Node] = {}
 
     def to_python(
         self, value: Iterable[Mapping] | None, **kwargs
@@ -134,16 +135,19 @@ class ReferenceDataType(BaseDataType):
                 raise ValueError(msg)
 
     def validate_multivalue(self, parsed: list[Reference] | None, node, nodeid):
-        if not parsed:
+        if not parsed or len(parsed) <= 1:
             return
         if not node:
             if not nodeid:
                 raise ValueError
-            try:
-                node = Node.objects.get(nodeid=nodeid)
-            except Node.DoesNotExist:
-                return
-        if not node.config.get("multiValue") and len(parsed) > 1:
+            nodeid_str = str(nodeid)
+            if nodeid_str not in self._node_cache:
+                try:
+                    self._node_cache[nodeid_str] = Node.objects.get(nodeid=nodeid)
+                except Node.DoesNotExist:
+                    return
+            node = self._node_cache[nodeid_str]
+        if not node.config.get("multiValue"):
             raise ValueError(_("This node does not allow multiple references."))
 
     @staticmethod

--- a/arches_controlled_lists/datatypes/datatypes.py
+++ b/arches_controlled_lists/datatypes/datatypes.py
@@ -115,14 +115,14 @@ class ReferenceDataType(BaseDataType):
         if not references:
             return
         for reference in references:
-            pref_label_languages = [
-                label.language_id
-                for label in reference.labels
-                if label.valuetype_id == "prefLabel"
-            ]
-            if len(set(pref_label_languages)) < len(pref_label_languages):
-                msg = _("A reference can have only one prefLabel per language")
-                raise ValueError(msg)
+            pref_label_languages = set()
+            for label in reference.labels:
+                if label.valuetype_id == "prefLabel":
+                    if label.language_id in pref_label_languages:
+                        raise ValueError(
+                            _("A reference can have only one prefLabel per language")
+                        )
+                    pref_label_languages.add(label.language_id)
 
     def validate_list_item_consistency(self, references: list[Reference] | None):
         if not references:

--- a/tests/reference_datatype_tests.py
+++ b/tests/reference_datatype_tests.py
@@ -1,6 +1,7 @@
 import uuid
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
+
 
 from django.test import TestCase
 from rdflib import URIRef
@@ -728,10 +729,12 @@ class ReferenceDataTypeTests(TestCase):
         )
 
         # Valid nodeid → fetches node, single value is allowed on non-multiValue node
-        reference.validate_multivalue(parsed, None, str(node.pk))
+        self.assertIsNone(reference.validate_multivalue(parsed, None, str(node.pk)))
 
         # Nonexistent nodeid → Node.DoesNotExist caught, returns without raising
-        reference.validate_multivalue(parsed, None, str(uuid.uuid4()))
+        self.assertIsNone(
+            reference.validate_multivalue(parsed, None, str(uuid.uuid4()))
+        )
 
         two_refs = parsed + parsed
         # Neither node nor nodeid → raises ValueError
@@ -741,6 +744,22 @@ class ReferenceDataTypeTests(TestCase):
         # Two references on a non-multiValue node → raises ValueError
         with self.assertRaises(ValueError):
             reference.validate_multivalue(two_refs, node, None)
+
+        # Two references on a multiValue node passes validation
+        self.assertIsNone(
+            reference.validate_multivalue(
+                two_refs, None, str(ListTests.node_using_list2.pk)
+            )
+        )
+
+        # Node.DoesNotExist with multiValue True (should not raise, should return None)
+        # Patch Node.objects.get to raise DoesNotExist and simulate multiValue True
+        with patch("arches.app.models.models.Node.objects.get") as mock_get:
+            mock_get.side_effect = Node.DoesNotExist
+            # Should return None, not raise
+            self.assertIsNone(
+                reference.validate_multivalue(two_refs, None, str(uuid.uuid4()))
+            )
 
     def test_lookup_listitem_from_label(self):
         reference = ReferenceDataType()

--- a/tests/reference_datatype_tests.py
+++ b/tests/reference_datatype_tests.py
@@ -136,7 +136,7 @@ class ReferenceDataTypeTests(TestCase):
         self.assertEqual(len(errors), 1, errors)
 
         # User error (missing arguments)
-        errors = reference.validate(value=[data])
+        errors = reference.validate(value=data)
         self.assertEqual(len(errors), 1, errors)
 
     def test_tile_clean(self):
@@ -723,7 +723,7 @@ class ReferenceDataTypeTests(TestCase):
                         }
                     ],
                     "list_id": str(uuid.uuid4()),
-                }
+                },
             ]
         )
 
@@ -733,12 +733,12 @@ class ReferenceDataTypeTests(TestCase):
         # Nonexistent nodeid → Node.DoesNotExist caught, returns without raising
         reference.validate_multivalue(parsed, None, str(uuid.uuid4()))
 
+        two_refs = parsed + parsed
         # Neither node nor nodeid → raises ValueError
         with self.assertRaises(ValueError):
-            reference.validate_multivalue(parsed, None, None)
+            reference.validate_multivalue(two_refs, None, None)
 
         # Two references on a non-multiValue node → raises ValueError
-        two_refs = parsed + parsed
         with self.assertRaises(ValueError):
             reference.validate_multivalue(two_refs, node, None)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -172,7 +172,7 @@ class ListTests(TestCase):
             nodegroup=cls.nodegroup,
             istopnode=False,
             config={
-                "multiValue": False,
+                "multiValue": True,
                 "controlledList": str(cls.list2.pk),
             },
         )


### PR DESCRIPTION
Improve validation performance:

Minimize node queries by querying only when necessary and by using node cache. Also, during validation, return all errors rather than only the first error. 