### PR TITLE
Update get_display_value to get nodeid instead of pk

### DIFF
--- a/arches_controlled_lists/datatypes/datatypes.py
+++ b/arches_controlled_lists/datatypes/datatypes.py
@@ -258,7 +258,7 @@ class ReferenceDataType(BaseDataType):
     def get_display_value(self, tile, node, **kwargs):
         requested_language = kwargs.pop("language", None)
         node_data = self.get_tile_data(tile)
-        value = node_data.get(str(node.pk), None)
+        value = node_data.get(str(node.nodeid), None)
         references = self.to_python(value)
         if not references:
             return ""


### PR DESCRIPTION
 To fix label based graph end point which sends SimpleNamespace instead of Node (lacks pk)
 Following all other datatypes