### PR TITLE
Protect against TypeError during skos import

### DIFF
--- a/arches_controlled_lists/utils/skos.py
+++ b/arches_controlled_lists/utils/skos.py
@@ -137,8 +137,8 @@ class SKOSReader(SKOSReader):
                         object_language = (
                             allowed_languages[object.language] or default_lang
                         )
-                        relation_or_value_type = predicate.replace(SKOS, "").replace(
-                            ARCHES, ""
+                        relation_or_value_type = str(predicate).replace(str(SKOS), "").replace(
+                            str(ARCHES), ""
                         )
                         list_item_value = ListItemValue(
                             list_item=list_item,


### PR DESCRIPTION
skos import can fail because the SKOS variable is no longer a string. This issue seems to has arisen from the rdflib upgrade. 

``` 
_import_controlled_list_from_file
    skos.save_controlled_lists_from_skos(
  File "/arches-controlled-lists/arches_controlled_lists/utils/skos.py", line 140, in save_controlled_lists_from_skos
    relation_or_value_type = predicate.replace(SKOS, "").replace(
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: replace() argument 1 must be str, not DefinedNamespaceMeta
```
